### PR TITLE
Implement MkTraverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Instances derivations are available for the following type classes:
 * `Hash`
 * `Functor`
 * `Foldable` 
+* `Traverse` 
 * `Show` 
 * `Monoid` and `MonoidK`
 * `Semigroup` and `SemigroupK`

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -140,6 +140,18 @@ object cached {
     : Functor[F] = ev.value
   }
 
+  object foldable {
+    implicit def kittensMkFoldable[F[_]](
+       implicit refute: Refute[Foldable[F]], ev: Cached[MkFoldable[F]])
+    : Foldable[F] = ev.value
+  }
+
+  object traverse{
+    implicit def kittensMkTraverse[F[_]](
+       implicit refute: Refute[Traverse[F]], ev: Cached[MkTraverse[F]])
+    : Traverse[F] = ev.value
+  }
+
   object show {
     implicit def kittensMkshow[A](
       implicit refute: Refute[Show[A]], ev: Cached[MkShow[A]])
@@ -225,6 +237,8 @@ object semi {
   def showPretty[A](implicit ev: MkShowPretty[A]): ShowPretty[A] = ev
 
   def foldable[F[_]](implicit F: MkFoldable[F]): Foldable[F] = F
+
+  def traverse[F[_]](implicit F: MkTraverse[F]): Traverse[F] = F
 
   def monoid[T](implicit T: MkMonoid[T]): Monoid[T] = T
 

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -92,6 +92,7 @@ object auto {
 
   object foldable extends MkFoldableDerivation
 
+  object traverse extends MkTraverseDerivation
 
 }
 

--- a/core/src/main/scala/cats/derived/traverse.scala
+++ b/core/src/main/scala/cats/derived/traverse.scala
@@ -51,9 +51,7 @@ object MkTraverse extends MkTraverseDerivation {
   private[derived] implicit class SafeTraverse[F[_]](val F: Traverse[F]) extends AnyVal {
     def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]] = F match {
       case mk: MkTraverse[F] => mk.safeTraverse(fa)(f)
-      case _ =>
-        type EvalG[T] = Eval[G[T]]
-        Eval.later(F.traverse[EvalG, A, B](fa)(f)(aEval[G]).value)
+      case _ => F.traverse[λ[t => Eval[G[t]]], A, B](fa)(f)(aEval[G])
     }
   }
 }

--- a/core/src/main/scala/cats/derived/traverse.scala
+++ b/core/src/main/scala/cats/derived/traverse.scala
@@ -1,0 +1,93 @@
+package cats.derived
+
+import cats.syntax.all._
+import cats.{Applicative, Eval, Monoid, Traverse}
+import shapeless._
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Could not derive an instance of Traverse[${F}]")
+trait MkTraverse[F[_]] extends Traverse[F] {
+
+  def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
+
+  override def foldMap[A, B: Monoid](fa: F[A])(f: A => B): B = {
+    traverse[cats.data.Const[B, ?], A, B](fa) { a => cats.data.Const(f(a)) } getConst
+  }
+
+  override def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
+    foldMap(fa)(f.curried andThen defer)(fMonoid(_ compose _)).apply(lb)
+  }
+
+  override def foldLeft[A, B](fa: F[A], b: B)(f: (B, A) => B): B =
+    foldMap[A, B => B](fa) { a => b => f(b, a) }(fMonoid(_ andThen _)).apply(b)
+
+  private def fMonoid[A](c: (A => A, A => A) => (A => A)): Monoid[A => A] = new Monoid[A => A] {
+    def combine(f: A => A, g: A => A): A => A = c(f, g)
+
+    def empty: A => A = identity
+  }
+
+  private def defer[B](f: Eval[B] => Eval[B]): Eval[B] => Eval[B] =
+    evalB => Eval.defer(f(evalB))
+
+}
+
+object MkTraverse extends MkTraverseDerivation {
+  def apply[F[_]](implicit mff: MkTraverse[F]): MkTraverse[F] = mff
+}
+
+trait MkTraverseDerivation extends MkTraverse0 {
+  implicit val mkTraverseId: MkTraverse[shapeless.Id] = new MkTraverse[shapeless.Id] {
+    override def traverse[G[_] : Applicative, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] = f(fa)
+  }
+}
+
+trait MkTraverse0 extends MkTraverse1 {
+  // Induction step for products
+  implicit def mkTraverseHcons[F[_]](implicit ihc: IsHCons1[F, Traverse, MkTraverse]): MkTraverse[F] = new MkTraverse[F] {
+    override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] = {
+      val (hd, tl) = ihc.unpack(fa)
+
+      (ihc.fh.traverse(hd)(f), ihc.ft.traverse(tl)(f)).mapN(ihc.pack(_, _))
+    }
+
+  }
+
+  // Induction step for coproducts
+  implicit def mkTraverseCcons[F[_]](implicit icc: IsCCons1[F, Traverse, MkTraverse]): MkTraverse[F] = new MkTraverse[F] {
+    override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] = {
+      val gUnpacked: G[Either[icc.H[B], icc.T[B]]] =
+        icc.unpack(fa) match {
+          case Left(hd) => icc.fh.traverse(hd)(f).map(Left(_))
+          case Right(tl) => icc.ft.traverse(tl)(f).map(Right(_))
+        }
+
+      gUnpacked.map(icc.pack)
+    }
+
+  }
+
+}
+
+trait MkTraverse1 extends MkTraverse2 {
+  implicit def mkTraverseSplit[F[_]](implicit split: Split1[F, Traverse, Traverse]): MkTraverse[F] = new MkTraverse[F] {
+
+    override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+      split.fo.traverse(split.unpack(fa))(split.fi.traverse(_)(f)).map(split.pack)
+
+  }
+}
+
+trait MkTraverse2 extends MkTraverse3 {
+  implicit def mkTraverseGeneric[F[_]](implicit gen: Generic1[F, MkTraverse]): MkTraverse[F] = new MkTraverse[F] {
+    override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+      gen.fr.traverse(gen.to(fa))(f).map(gen.from)
+  }
+}
+
+trait MkTraverse3 {
+  implicit def mkTraverseConstTraverse[T]: MkTraverse[Const[T]#λ] = new MkTraverse[Const[T]#λ] {
+    def traverse[G[_] : Applicative, A, B](fa: T)(f: A => G[B]): G[T] = fa.pure[G]
+  }
+}

--- a/core/src/main/scala/cats/derived/traverse.scala
+++ b/core/src/main/scala/cats/derived/traverse.scala
@@ -1,5 +1,6 @@
 package cats.derived
 
+import cats.derived.MkTraverse.SafeTraverse
 import cats.syntax.all._
 import cats.{Applicative, Eval, Monoid, Traverse}
 import shapeless._
@@ -9,7 +10,10 @@ import scala.annotation.implicitNotFound
 @implicitNotFound("Could not derive an instance of Traverse[${F}]")
 trait MkTraverse[F[_]] extends Traverse[F] {
 
-  def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
+  override def traverse[G[_], A, B](fa: F[A])(f: A => G[B])(implicit evidence$1: Applicative[G]): G[F[B]] =
+    safeTraverse(fa)(a => Eval.now(f(a))).value
+
+  def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]]
 
   override def foldMap[A, B: Monoid](fa: F[A])(f: A => B): B = {
     traverse[cats.data.Const[B, ?], A, B](fa) { a => cats.data.Const(f(a)) } getConst
@@ -35,11 +39,20 @@ trait MkTraverse[F[_]] extends Traverse[F] {
 
 object MkTraverse extends MkTraverseDerivation {
   def apply[F[_]](implicit mff: MkTraverse[F]): MkTraverse[F] = mff
+
+  private[derived] implicit class SafeTraverse[F[_]](val F: Traverse[F]) extends AnyVal {
+    def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]] = F match {
+      case mk: MkTraverse[F] => mk.safeTraverse(fa)(f)
+      case _ =>
+        type EvalG[T] = Eval[G[T]]
+        Eval.later(F.traverse[EvalG, A, B](fa)(f)(aEval[G]).value)
+    }
+  }
 }
 
 trait MkTraverseDerivation extends MkTraverse0 {
   implicit val mkTraverseId: MkTraverse[shapeless.Id] = new MkTraverse[shapeless.Id] {
-    override def traverse[G[_] : Applicative, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] = f(fa)
+    override def safeTraverse[G[_] : Applicative, A, B](fa: Id[A])(f: A => Eval[G[B]]): Eval[G[Id[B]]] = f(fa)
   }
 }
 
@@ -47,27 +60,27 @@ trait MkTraverse0 extends MkTraverse1 {
   // Induction step for products
   implicit def mkTraverseHcons[F[_]](implicit ihc: IsHCons1[F, TraverseOrMk, MkTraverse]): MkTraverse[F] =
     new MkTraverse[F] {
-      override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] = {
-        val (hd, tl) = ihc.unpack(fa)
-
-        (ihc.fh.unify.traverse(hd)(f), ihc.ft.traverse(tl)(f)).mapN(ihc.pack(_, _))
+      override def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]] = {
+        for {
+          ht <- Eval.now(ihc.unpack(fa))
+          th <- ihc.fh.unify.safeTraverse(ht._1)(f)
+          tt <- ihc.ft.safeTraverse(ht._2)(f)
+        } yield (th, tt).mapN(ihc.pack(_, _))
       }
-
     }
 
   // Induction step for coproducts
   implicit def mkTraverseCcons[F[_]](implicit icc: IsCCons1[F, TraverseOrMk, MkTraverse]): MkTraverse[F] =
     new MkTraverse[F] {
-      override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] = {
-        val gUnpacked: G[Either[icc.H[B], icc.T[B]]] =
+      override def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]] = {
+        val gUnpacked: Eval[G[Either[icc.H[B], icc.T[B]]]] =
           icc.unpack(fa) match {
-            case Left(hd) => icc.fh.unify.traverse(hd)(f).map(Left(_))
-            case Right(tl) => icc.ft.traverse(tl)(f).map(Right(_))
+            case Left(hd) => aEval[G].map(icc.fh.unify.safeTraverse(hd)(f))(Left(_))
+            case Right(tl) => aEval[G].map(icc.ft.safeTraverse(tl)(f))(Right(_))
           }
 
-        gUnpacked.map(icc.pack)
+        aEval[G].map(gUnpacked)(icc.pack)
       }
-
     }
 
 }
@@ -75,17 +88,16 @@ trait MkTraverse0 extends MkTraverse1 {
 trait MkTraverse1 extends MkTraverse2 {
   implicit def mkTraverseSplit[F[_]](implicit split: Split1[F, TraverseOrMk, TraverseOrMk]): MkTraverse[F] =
     new MkTraverse[F] {
-      override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
-        split.fo.unify.traverse(split.unpack(fa))(split.fi.unify.traverse(_)(f)).map(split.pack)
-
+      override def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]] =
+        split.fo.unify.safeTraverse(split.unpack(fa))(split.fi.unify.safeTraverse(_)(f)).map(_.map(split.pack))
     }
 }
 
 trait MkTraverse2 extends MkTraverse3 {
   implicit def mkTraverseGeneric[F[_]](implicit gen: Generic1[F, MkTraverse]): MkTraverse[F] =
     new MkTraverse[F] {
-      override def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
-        gen.fr.traverse(gen.to(fa))(f).map(gen.from)
+      override def safeTraverse[G[_] : Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]] =
+        gen.fr.safeTraverse(gen.to(fa))(f).map(_.map(gen.from))
     }
 }
 
@@ -93,7 +105,11 @@ trait MkTraverse3 {
 
   protected type TraverseOrMk[F[_]] = Traverse[F] OrElse MkTraverse[F]
 
+  protected def aEval[G[_] : Applicative] = Applicative[Eval].compose[G]
+
   implicit def mkTraverseConstTraverse[T]: MkTraverse[Const[T]#λ] = new MkTraverse[Const[T]#λ] {
-    def traverse[G[_] : Applicative, A, B](fa: T)(f: A => G[B]): G[T] = fa.pure[G]
+    def unsafeTraverse[G[_] : Applicative, A, B](fa: T)(f: A => G[B]): G[T] = fa.pure[G]
+
+    override def safeTraverse[G[_] : Applicative, A, B](fa: T)(f: A => Eval[G[B]]): Eval[G[T]] = Eval.now(fa.pure[G])
   }
 }

--- a/core/src/main/scala/cats/derived/traverse.scala
+++ b/core/src/main/scala/cats/derived/traverse.scala
@@ -7,6 +7,14 @@ import shapeless._
 
 import scala.annotation.implicitNotFound
 
+/**
+  * This trait extends `Traverse` and implements it's fold methods.
+  * The overriden implementation can be removed as soon as issue
+  * <a href="https://github.com/typelevel/cats/issues/107#issuecomment-393797529">cats-107</a>
+  * gets resolved.
+  * The current implementation is based on a proposal posted by @Baccata in a comment to the issue.
+  *
+  */
 @implicitNotFound("Could not derive an instance of Traverse[${F}]")
 trait MkTraverse[F[_]] extends Traverse[F] {
 

--- a/core/src/test/scala/cats/derived/traverse.scala
+++ b/core/src/test/scala/cats/derived/traverse.scala
@@ -1,0 +1,137 @@
+package cats
+package derived
+
+import cats.derived.TestDefns._
+import cats.implicits._
+import cats.laws.discipline.TraverseTests
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.FreeSpec
+import shapeless.test.illTyped
+
+class TraverseSuite extends FreeSpec {
+
+  "traverse" - {
+
+    "passes cats traverse tests" in {
+      implicit def genTestClass[T: Arbitrary]: Arbitrary[TestTraverse[T]] = Arbitrary {
+        for {
+          i <- Gen.posNum[Int]
+          t <- arbitrary[T]
+          d <- Gen.posNum[Double]
+          tt <- Gen.listOf(arbitrary[T])
+          s <- Gen.alphaStr
+        } yield TestTraverse[T](i, t, d, tt, s)
+      }
+
+      implicit def eqTestClass[T: Eq]: Eq[TestTraverse[T]] = semi.eq
+
+      TraverseTests[TestTraverse](semi.traverse[TestTraverse]).traverse[Int, Double, String, Long, Option, Option].all.check()
+    }
+
+    "derives an instance for" - {
+      // occasional map, as a special case of traverse[Id,_], is just fine and is easier to test
+      // the laws were checked in the previous test
+
+      "for a Tree" in {
+        implicit val F = semi.traverse[Tree]
+
+        val tree: Tree[String] =
+          Node(
+            Leaf("12"),
+            Node(
+              Leaf("3"),
+              Leaf("4")
+            )
+          )
+
+        val expected: List[Tree[Char]] = List(
+          Node(
+            Leaf('1'),
+            Node(
+              Leaf('3'),
+              Leaf('4')
+            )
+          ),
+          Node(
+            Leaf('2'),
+            Node(
+              Leaf('3'),
+              Leaf('4')
+            )
+          )
+        )
+
+        assert(tree.traverse(_.toCharArray.toList) == expected)
+      }
+
+      "for a nested List[List[_]] (with alias)" in {
+        illTyped("derive.traverse[λ[t => List[List[t]]]]")
+        type LList[T] = List[List[T]]
+        val F = semi.traverse[LList]
+
+        val l = List(List(1), List(2, 3), List(4, 5, 6), List(), List(7))
+        val expected = List(List(2), List(3, 4), List(5, 6, 7), List(), List(8))
+
+        assert(F.map(l)(_ + 1) == expected)
+      }
+
+      "for a pair on the left (with alias)" in {
+        illTyped("derive.traverse[(?, String)]")
+
+        def F[R]: Traverse[(?, R)] = {
+          type Pair[L] = (L, R)
+          semi.traverse[Pair]
+        }
+
+        val pair = (42, "shapeless")
+        assert(F[String].map(pair)(_ / 2) == (21, "shapeless"))
+      }
+
+      "for a pair on the right" in {
+        def F[L]: Traverse[(L, ?)] = semi.traverse[(L, ?)]
+
+        val pair = (42, "shapeless")
+        assert(F[Int].map(pair)(_.length) == (42, 9))
+      }
+
+    }
+
+    "respects existing instances for a generic ADT " in {
+      implicit val F = semi.traverse[GenericAdt]
+      val adt: GenericAdt[Int] = GenericAdtCase(Some(2))
+      assert(adt.map(_ + 1) == GenericAdtCase(Some(3)))
+    }
+
+    "is stack safe" in {
+      implicit val F = semi.traverse[IList]
+
+      val llarge = List.range(1, 10000)
+      val large = IList.fromSeq(llarge)
+
+      val actual = large.traverse[Option, Int](i => Option(i + 1)).map(IList.toList)
+      val expected = Option(llarge.map(_ + 1))
+
+      assert(actual == expected)
+    }
+
+    "auto derivation work" in {
+      import cats.derived.auto.traverse._
+
+      val testInstance = TestTraverse(1, "ab", 2.0, List("cd"), "3")
+
+      val expected = List(
+        TestTraverse(1, 'a', 2.0, List('c'), "3"),
+        TestTraverse(1, 'a', 2.0, List('d'), "3"),
+        TestTraverse(1, 'b', 2.0, List('c'), "3"),
+        TestTraverse(1, 'b', 2.0, List('d'), "3")
+      )
+      val actual = testInstance.traverse(_.toCharArray.toList)
+
+      assert(actual == expected)
+    }
+  }
+}
+
+private case class TestTraverse[T](i: Int, t: T, d: Double, tt: List[T], s: String)
+

--- a/core/src/test/scala/cats/derived/traverse.scala
+++ b/core/src/test/scala/cats/derived/traverse.scala
@@ -131,29 +131,31 @@ class TraverseSuite extends FreeSpec {
       assert(actual == expected)
     }
 
-    "implements folds correctly" in {
-      implicit val F = semi.traverse[IList]
+    "folds" - {
 
-      val iList = IList.fromSeq(List.range(1, 5))
+      "are implemented correctly" in {
+        implicit val F = semi.traverse[IList].asInstanceOf[MkTraverse[IList]]
 
-      // just basic sanity checks
-      assert(F.foldLeft(iList, "x")(_ + _) == "x1234")
-      assert(F.foldRight(iList, Now("x"))((buff, eval) => eval.map(_ + buff)).value == "x4321")
-      assert(F.foldMap(iList)(_.toDouble) == 10)
+        val iList = IList.fromSeq(List.range(1, 5))
+
+        // just basic sanity checks
+        assert(F.foldLeft(iList, "x")(_ + _) == "x1234")
+        assert(F.foldRight(iList, Now("x"))((i, b) => b.map(i + _)).value == "1234x")
+        assert(F.foldMap(iList)(_.toDouble) == 10)
+      }
+
+      "are stack safe" in {
+        implicit val F = semi.traverse[IList]
+
+        val n = 10000
+        val llarge = IList.fromSeq(List.range(1, n))
+
+        val expected = n * (n - 1) / 2
+        val evalActual = F.foldRight(llarge, Now(0))((buff, eval) => eval.map(_ + buff))
+
+        assert(evalActual.value == expected)
+      }
     }
-
-    "fold right is still stack safe" in {
-      implicit val F = semi.traverse[IList]
-
-      val n = 10000
-      val llarge = IList.fromSeq(List.range(1, 10000))
-
-      val expected = n * (n - 1) / 2
-      val evalActual = F.foldRight(llarge, Now(0))((buff, eval) => eval.map(_ + buff))
-
-      assert(evalActual.value == expected)
-    }
-
   }
 }
 

--- a/core/src/test/scala/cats/derived/traverse.scala
+++ b/core/src/test/scala/cats/derived/traverse.scala
@@ -130,6 +130,30 @@ class TraverseSuite extends FreeSpec {
 
       assert(actual == expected)
     }
+
+    "implements folds correctly" in {
+      implicit val F = semi.traverse[IList]
+
+      val iList = IList.fromSeq(List.range(1, 5))
+
+      // just basic sanity checks
+      assert(F.foldLeft(iList, "x")(_ + _) == "x1234")
+      assert(F.foldRight(iList, Now("x"))((buff, eval) => eval.map(_ + buff)).value == "x4321")
+      assert(F.foldMap(iList)(_.toDouble) == 10)
+    }
+
+    "fold right is still stack safe" in {
+      implicit val F = semi.traverse[IList]
+
+      val n = 10000
+      val llarge = IList.fromSeq(List.range(1, 10000))
+
+      val expected = n * (n - 1) / 2
+      val evalActual = F.foldRight(llarge, Now(0))((buff, eval) => eval.map(_ + buff))
+
+      assert(evalActual.value == expected)
+    }
+
   }
 }
 

--- a/core/src/test/scala/cats/sequence/TraverseHListSuite.scala
+++ b/core/src/test/scala/cats/sequence/TraverseHListSuite.scala
@@ -11,7 +11,7 @@ import cats.derived._
 import org.scalacheck.Prop.forAll
 
 
-class TraverseSuite extends KittensSuite {
+class TraverseHListSuite extends KittensSuite {
 
   def optToValidation[T](opt: Option[T]): Validated[String, T] = Validated.fromOption(opt, "Nothing Here")
 


### PR DESCRIPTION
I wanned to learn how the type-class derivation work. Thus I attempted to implement derivation for `Traverse`, since it was not present in kittens.

After a brief discussion on gitter I added it to kittens as a separate class with the _fold_ methods implemented using `traverse`.

## Further TODOs

 * [x] write unit tests
 * [x] make it stacksafe
 * [x] attribute the [original author](https://github.com/typelevel/cats/issues/107#issuecomment-393797529) of default implementation of fold methods

## Questions

 * Is the code style fine?
 * Should all the files have a licence header?