### PR TITLE
Derivation of half of the type-classes fails on simple case class

### DIFF
--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -21,6 +21,9 @@ import org.scalacheck.{Cogen, Arbitrary}, Arbitrary.arbitrary
 import scala.annotation.tailrec
 
 object TestDefns {
+
+  case class Interleaved[T](i: Int, t: T, d: Double, tt: List[T], s: String)
+
   sealed trait IList[A]
   final case class ICons[A](head: A, tail: IList[A]) extends IList[A]
   final case class INil[A]() extends IList[A]

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -43,7 +43,7 @@ class EmptySuite extends FreeSpec {
     }
 
     "derives an instance for Interleaved[T]" in {
-      assertCompiles("semi.empty[TestDefns.Interleaved[Int]]")
+      semi.empty[TestDefns.Interleaved[Int]]
     }
 
   }

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -41,6 +41,11 @@ class EmptySuite extends FreeSpec {
       implicit val E = semi.empty[Outer]
       assert(Empty[Outer].empty == Outer(Inner(1)))
     }
+
+    "derives an instance for Interleaved[T]" in {
+      assertCompiles("semi.empty[TestDefns.Interleaved[Int]]")
+    }
+
   }
 
   "full auto derivation" - {

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -68,4 +68,9 @@ class EmptyKSuite extends KittensSuite {
 
     assert(E.empty == (Nil, Nil))
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.emptyK[TestDefns.Interleaved]")
+  }
+
 }

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -70,7 +70,7 @@ class EmptyKSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.emptyK[TestDefns.Interleaved]")
+    semi.emptyK[TestDefns.Interleaved]
   }
 
 }

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -86,7 +86,7 @@ class EqSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.eq[TestDefns.Interleaved[Int]]")
+    semi.eq[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -84,6 +84,11 @@ class EqSuite extends KittensSuite {
     import cats.instances.all._
     semi.eq[Large]
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.eq[TestDefns.Interleaved[Int]]")
+  }
+
 }
 
 object EqSuite {

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -61,8 +61,12 @@ class FoldableSuite extends KittensSuite {
     assert(larger.value == llarge.map(_ + 1))
   }
 
-  test("Foldable[Tree]") {
-    val F = Foldable[Tree]
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.foldable[TestDefns.Interleaved]")
+  }
+
+  test("foldable.semi[Tree]") {
+    val F = semi.foldable[Tree]
 
     val tree: Tree[String] =
       Node(

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -62,7 +62,7 @@ class FoldableSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.foldable[TestDefns.Interleaved]")
+    semi.foldable[TestDefns.Interleaved]
   }
 
   test("foldable.semi[Tree]") {

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -105,7 +105,7 @@ class FunctorSuite extends FreeSpec with FunctorSyntax {
     }
 
     "derives an instance for Interleaved[T]" in {
-      assertCompiles("semi.functor[TestDefns.Interleaved]")
+      semi.functor[TestDefns.Interleaved]
     }
 
   }

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -103,6 +103,11 @@ class FunctorSuite extends FreeSpec with FunctorSyntax {
       val pair = (42, "shapeless")
       assert(F[Int].map(pair)(_.length) == (42, 9))
     }
+
+    "derives an instance for Interleaved[T]" in {
+      assertCompiles("semi.functor[TestDefns.Interleaved]")
+    }
+
   }
 
   "full auto derivation" - {

--- a/core/src/test/scala/cats/derived/hash.scala
+++ b/core/src/test/scala/cats/derived/hash.scala
@@ -35,6 +35,9 @@ class HashSuite extends KittensSuite {
     }
   })
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.hash[TestDefns.Interleaved[Int]]")
+  }
 
   test("existing Hash instances in scope are respected auto")(check {
 

--- a/core/src/test/scala/cats/derived/hash.scala
+++ b/core/src/test/scala/cats/derived/hash.scala
@@ -36,7 +36,7 @@ class HashSuite extends KittensSuite {
   })
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.hash[TestDefns.Interleaved[Int]]")
+    semi.hash[TestDefns.Interleaved[Int]]
   }
 
   test("existing Hash instances in scope are respected auto")(check {

--- a/core/src/test/scala/cats/derived/iterable.scala
+++ b/core/src/test/scala/cats/derived/iterable.scala
@@ -88,4 +88,9 @@ class IterableSuite extends KittensSuite {
     val i = I.iterator
     assert(I.map(_.length).sum == 13)
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.iterable[TestDefns.Interleaved, Int]")
+  }
+
 }

--- a/core/src/test/scala/cats/derived/iterable.scala
+++ b/core/src/test/scala/cats/derived/iterable.scala
@@ -90,7 +90,7 @@ class IterableSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.iterable[TestDefns.Interleaved, Int]")
+    semi.iterable[TestDefns.Interleaved, Int]
   }
 
 }

--- a/core/src/test/scala/cats/derived/monoid.scala
+++ b/core/src/test/scala/cats/derived/monoid.scala
@@ -38,7 +38,7 @@ class MonoidSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.monoid[TestDefns.Interleaved[Int]]")
+    semi.monoid[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/monoid.scala
+++ b/core/src/test/scala/cats/derived/monoid.scala
@@ -37,6 +37,10 @@ class MonoidSuite extends KittensSuite {
     checkAll("Monoid[Rec]", MonoidTests[Rec].monoid)
   }
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.monoid[TestDefns.Interleaved[Int]]")
+  }
+
 }
 
 object MonoidSuite {

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -33,4 +33,10 @@ class MonoidKSuite extends KittensSuite {
     checkAll("AutoMonoidK[ComplexProduct]", MonoidTests[ComplexProduct[Char]].monoid)
 
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.monoidK[TestDefns.Interleaved]")
+  }
+
+
 }

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -35,7 +35,7 @@ class MonoidKSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.monoidK[TestDefns.Interleaved]")
+    semi.monoidK[TestDefns.Interleaved]
   }
 
 

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -49,6 +49,11 @@ class OrderSuite extends KittensSuite {
   })
 
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.order[TestDefns.Interleaved[Int]]")
+  }
+
+
   test("existing Order instances in scope are respected for auto derivation")(check {
 
     import auto.order._

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -50,7 +50,7 @@ class OrderSuite extends KittensSuite {
 
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.order[TestDefns.Interleaved[Int]]")
+    semi.order[TestDefns.Interleaved[Int]]
   }
 
 

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -47,6 +47,10 @@ class PartialOrderSuite extends KittensSuite {
     }
   })
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.partialOrder[TestDefns.Interleaved[Int]]")
+  }
+
   test("existing PartialOrder instances in scope are respected for auto derivation")(check {
 
     import auto.partialOrder._

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -48,7 +48,7 @@ class PartialOrderSuite extends KittensSuite {
   })
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.partialOrder[TestDefns.Interleaved[Int]]")
+    semi.partialOrder[TestDefns.Interleaved[Int]]
   }
 
   test("existing PartialOrder instances in scope are respected for auto derivation")(check {

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -38,7 +38,7 @@ class PureSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.pure[TestDefns.Interleaved]")
+    semi.pure[TestDefns.Interleaved]
   }
 
   test("Pure[Some]") {

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -37,6 +37,10 @@ class PureSuite extends KittensSuite {
     assert(P.pure(23) == Some(23))
   }
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.pure[TestDefns.Interleaved]")
+  }
+
   test("Pure[Some]") {
     val P = Pure[Some]
 

--- a/core/src/test/scala/cats/derived/semigroup.scala
+++ b/core/src/test/scala/cats/derived/semigroup.scala
@@ -46,5 +46,8 @@ class SemigroupSuite extends KittensSuite {
   implicit val eqOuter: Eq[Outer] = Eq.fromUniversalEquals
   checkAll("Semigroup[Outer]", SemigroupTests[Outer].semigroup)
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.semigroup[TestDefns.Interleaved[Int]]")
+  }
 
 }

--- a/core/src/test/scala/cats/derived/semigroup.scala
+++ b/core/src/test/scala/cats/derived/semigroup.scala
@@ -47,7 +47,7 @@ class SemigroupSuite extends KittensSuite {
   checkAll("Semigroup[Outer]", SemigroupTests[Outer].semigroup)
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.semigroup[TestDefns.Interleaved[Int]]")
+    semi.semigroup[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -34,6 +34,11 @@ class SemigroupKSuite extends KittensSuite {
     implicit val sg = SemigroupK[ComplexProduct].algebra[Char]
     checkAll("Auto SemigroupK[ComplexProduct]", SemigroupTests[ComplexProduct[Char]].semigroup)
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.semigroupK[TestDefns.Interleaved]")
+  }
+
 }
 
 object SemigroupKSuite {

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -36,7 +36,7 @@ class SemigroupKSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.semigroupK[TestDefns.Interleaved]")
+    semi.semigroupK[TestDefns.Interleaved]
   }
 
 }

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -128,6 +128,10 @@ class ShowTests extends KittensSuite {
     )
   }
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.show[TestDefns.Interleaved[Int]]")
+  }
+
 }
 
 

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -129,7 +129,7 @@ class ShowTests extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.show[TestDefns.Interleaved[Int]]")
+    semi.show[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -206,4 +206,9 @@ class ShowPrettyTests extends KittensSuite {
       """.stripMargin.trim
     )
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.showPretty[TestDefns.Interleaved[Int]]")
+  }
+
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -208,7 +208,7 @@ class ShowPrettyTests extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.showPretty[TestDefns.Interleaved[Int]]")
+    semi.showPretty[TestDefns.Interleaved[Int]]
   }
 
 }


### PR DESCRIPTION
# Summary
In Scala 2.13 I mentioned that there was a problem with implicit defs for both HCons and CCons being applicable on my simple `case class` with generic params interleaved with primitive values.

So far this PR adds failing tests to the test suites. Which broke more than I expected. For example the error log from `foldabe` goes crazy.

A fix could be found for example in `functor`, which is unaffected by the original problem. It exposes only `new Mk*[Const[T]#λ]`, keeping the remaining definitions `private[derived]`.

# Question

I just need to verify that this actually is a problem of kittens, not shapeless. Since, if I underestand it correctly it does not make sense to have both `HCons` and `CCons` applicable.

# TODOs

 * [x] add failing unit tests
 * [ ] fix by making some implicit defs private