### PR TITLE
Add Interleaved tests

### DIFF
--- a/core/src/main/scala/cats/derived/foldable.scala
+++ b/core/src/main/scala/cats/derived/foldable.scala
@@ -21,9 +21,7 @@ import shapeless._
 
 trait MkFoldable[F[_]] extends Foldable[F] {
   def foldLeft[A, B](fa: F[A], b: B)(f: (B, A) => B): B = safeFoldLeft(fa, b){ (b, a) => now(f(b, a)) }.value
-
   def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B]
-
   def safeFoldLeft[A, B](fa: F[A], b: B)(f: (B, A) => Eval[B]): Eval[B]
 }
 
@@ -35,9 +33,11 @@ trait MkFoldableDerivation extends MkFoldable0 {
   implicit val mkFoldableId: MkFoldable[shapeless.Id] =
     new MkFoldable[shapeless.Id] {
       def foldRight[A, B](fa: A, lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = f(fa, lb)
-
       def safeFoldLeft[A, B](fa: A, b: B)(f: (B, A) => Eval[B]): Eval[B] = now(f(b, fa).value)
     }
+
+  override implicit def mkFoldableConstFoldable[T]: MkFoldable[Const[T]#λ] =
+    super[MkFoldable0].mkFoldableConstFoldable
 }
 
 trait MkFoldable0 extends MkFoldable1 {
@@ -111,10 +111,11 @@ trait MkFoldable2 extends MkFoldable3 {
 }
 
 trait MkFoldable3 {
-  implicit def mkFoldableConstFoldable[T]: MkFoldable[Const[T]#λ] =
+
+  // For binary compatibility.
+  def mkFoldableConstFoldable[T]: MkFoldable[Const[T]#λ] =
     new MkFoldable[Const[T]#λ] {
       def foldRight[A, B](fa: T, lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = lb
-
       def safeFoldLeft[A, B](fa: T, b: B)(f: (B, A) => Eval[B]): Eval[B] = now(b)
     }
 

--- a/core/src/main/scala/cats/derived/functor.scala
+++ b/core/src/main/scala/cats/derived/functor.scala
@@ -39,21 +39,15 @@ object MkFunctor extends MkFunctorDerivation {
 }
 
 private[derived] abstract class MkFunctorDerivation extends MkFunctor1 {
-  import MkFunctor.SafeMap
-
   protected type FunctorOrMk[F[_]] = Functor[F] OrElse MkFunctor[F]
 
-  implicit val mkFunctorHNil: MkFunctor[Const[HNil]#λ] = new MkFunctor[Const[HNil]#λ] {
-    def safeMap[A, B](nil: HNil)(f: A => Eval[B]) = Eval.now(nil)
-  }
+  implicit val mkFunctorHNil: MkFunctor[Const[HNil]#λ] = mkFunctorConst
+  implicit val mkFunctorCNil: MkFunctor[Const[CNil]#λ] = mkFunctorConst
 
-  implicit val mkFunctorCNil: MkFunctor[Const[CNil]#λ] = new MkFunctor[Const[CNil]#λ] {
-    def safeMap[A, B](nil: CNil)(f: A => Eval[B]) = Eval.now(nil)
-  }
-
-  implicit def mkFunctorConst[T]: MkFunctor[Const[T]#λ] = new MkFunctor[Const[T]#λ] {
-    def safeMap[A, B](t: T)(f: A => Eval[B]) = Eval.now(t)
-  }
+  implicit def mkFunctorConst[T]: MkFunctor[Const[T]#λ] =
+    new MkFunctor[Const[T]#λ] {
+      def safeMap[A, B](t: T)(f: A => Eval[B]) = Eval.now(t)
+    }
 }
 
 private[derived] abstract class MkFunctor1 extends MkFunctor2 {

--- a/core/src/main/scala/cats/derived/iterable.scala
+++ b/core/src/main/scala/cats/derived/iterable.scala
@@ -108,6 +108,9 @@ object MkIterable extends MkIterable0 {
       def initialState[A](fa: F[A]): IterState[A] =
         ReturnI(fa.iterator)
     }
+
+  override implicit def mkIterableConst[T]: MkIterable[Const[T]#λ] =
+    super[MkIterable0].mkIterableConst
 }
 
 trait MkIterable0 extends MkIterable1 {
@@ -155,7 +158,8 @@ trait MkIterable2 extends MkIterable3 {
 trait MkIterable3 {
   import IterState._
 
-  implicit def mkIterableConst[T]: MkIterable[Const[T]#λ] =
+  // For binary compatibility.
+  def mkIterableConst[T]: MkIterable[Const[T]#λ] =
     new MkIterable[Const[T]#λ] {
       def initialState[A](fa: T): IterState[A] = Done
     }

--- a/core/src/main/scala/cats/derived/monoidk.scala
+++ b/core/src/main/scala/cats/derived/monoidk.scala
@@ -42,6 +42,9 @@ private[derived] abstract class MkMonoidK0 extends MkMonoidK0b {
         pack(fh.combineK(hx, hy), ft.combineK(tx, ty))
       }
     }
+
+  override implicit def mkMonoidKConst[T](implicit m: Monoid[T]): MkMonoidK[Const[T]#λ] =
+    super[MkMonoidK0b].mkMonoidKConst
 }
 
 private[derived] abstract class  MkMonoidK0b extends MkMonoidK1 {
@@ -108,8 +111,10 @@ private[derived] abstract class  MkMonoidK23 extends MkMonoidK4 {
 }
 
 private[derived] abstract class  MkMonoidK4 {
-  implicit def mkMonoidKConst[T](implicit m: Monoid[T])
-    : MkMonoidK[Const[T]#λ] = new MkMonoidK[Const[T]#λ] {
+
+  // For binary compatibility.
+  def mkMonoidKConst[T](implicit m: Monoid[T]): MkMonoidK[Const[T]#λ] =
+    new MkMonoidK[Const[T]#λ] {
       def empty[A] = m.empty
       def combineK[A](x: T, y: T) = m.combine(x, y)
     }

--- a/core/src/main/scala/cats/derived/semigroupk.scala
+++ b/core/src/main/scala/cats/derived/semigroupk.scala
@@ -42,6 +42,9 @@ private[derived] abstract class  MkSemigroupK0 extends MkSemigroupK0b {
         pack(fh.combineK(hx, hy), ft.combineK(tx, ty))
       }
     }
+
+  override implicit def mkSemigroupKConst[T](implicit sg: Semigroup[T]): MkSemigroupK[Const[T]#λ] =
+    super[MkSemigroupK0b].mkSemigroupKConst
 }
 
 private[derived] abstract class  MkSemigroupK0b extends MkSemigroupK1 {
@@ -102,8 +105,10 @@ private[derived] abstract class  MkSemigroupK3 extends MkSemigroupK4 {
 }
 
 trait MkSemigroupK4 {
-  implicit def mkSemigroupKConst[T](implicit sg: Semigroup[T])
-    : MkSemigroupK[Const[T]#λ] = new MkSemigroupK[Const[T]#λ] {
+
+  // For binary compatibility.
+  def mkSemigroupKConst[T](implicit sg: Semigroup[T]): MkSemigroupK[Const[T]#λ] =
+    new MkSemigroupK[Const[T]#λ] {
       def combineK[A](x: T, y: T) = sg.combine(x, y)
     }
 }

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -21,6 +21,9 @@ import org.scalacheck.{Cogen, Arbitrary}, Arbitrary.arbitrary
 import scala.annotation.tailrec
 
 object TestDefns {
+
+  case class Interleaved[T](i: Int, t: T, d: Double, tt: List[T], s: String)
+
   sealed trait IList[A]
   final case class ICons[A](head: A, tail: IList[A]) extends IList[A]
   final case class INil[A]() extends IList[A]

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -43,7 +43,7 @@ class EmptySuite extends FreeSpec {
     }
 
     "derives an instance for Interleaved[T]" in {
-      assertCompiles("semi.empty[TestDefns.Interleaved[Int]]")
+      semi.empty[TestDefns.Interleaved[Int]]
     }
 
   }

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -41,6 +41,11 @@ class EmptySuite extends FreeSpec {
       implicit val E = semi.empty[Outer]
       assert(Empty[Outer].empty == Outer(Inner(1)))
     }
+
+    "derives an instance for Interleaved[T]" in {
+      assertCompiles("semi.empty[TestDefns.Interleaved[Int]]")
+    }
+
   }
 
   "full auto derivation" - {

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -68,4 +68,9 @@ class EmptyKSuite extends KittensSuite {
 
     assert(E.empty == (Nil, Nil))
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.emptyK[TestDefns.Interleaved]")
+  }
+
 }

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -69,8 +69,4 @@ class EmptyKSuite extends KittensSuite {
     assert(E.empty == (Nil, Nil))
   }
 
-  test("derives an instance for Interleaved[T]") {
-    semi.emptyK[TestDefns.Interleaved]
-  }
-
 }

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -70,7 +70,7 @@ class EmptyKSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.emptyK[TestDefns.Interleaved]")
+    semi.emptyK[TestDefns.Interleaved]
   }
 
 }

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -86,7 +86,7 @@ class EqSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.eq[TestDefns.Interleaved[Int]]")
+    semi.eq[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -86,6 +86,7 @@ class EqSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
+    import cats.instances.all._
     semi.eq[TestDefns.Interleaved[Int]]
   }
 

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -84,6 +84,11 @@ class EqSuite extends KittensSuite {
     import cats.instances.all._
     semi.eq[Large]
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.eq[TestDefns.Interleaved[Int]]")
+  }
+
 }
 
 object EqSuite {

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -61,8 +61,12 @@ class FoldableSuite extends KittensSuite {
     assert(larger.value == llarge.map(_ + 1))
   }
 
-  test("Foldable[Tree]") {
-    val F = Foldable[Tree]
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.foldable[TestDefns.Interleaved]")
+  }
+
+  test("foldable.semi[Tree]") {
+    val F = semi.foldable[Tree]
 
     val tree: Tree[String] =
       Node(

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -62,7 +62,7 @@ class FoldableSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.foldable[TestDefns.Interleaved]")
+    semi.foldable[TestDefns.Interleaved]
   }
 
   test("foldable.semi[Tree]") {

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -105,7 +105,7 @@ class FunctorSuite extends FreeSpec with FunctorSyntax {
     }
 
     "derives an instance for Interleaved[T]" in {
-      assertCompiles("semi.functor[TestDefns.Interleaved]")
+      semi.functor[TestDefns.Interleaved]
     }
 
   }

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -103,6 +103,11 @@ class FunctorSuite extends FreeSpec with FunctorSyntax {
       val pair = (42, "shapeless")
       assert(F[Int].map(pair)(_.length) == (42, 9))
     }
+
+    "derives an instance for Interleaved[T]" in {
+      assertCompiles("semi.functor[TestDefns.Interleaved]")
+    }
+
   }
 
   "full auto derivation" - {

--- a/core/src/test/scala/cats/derived/hash.scala
+++ b/core/src/test/scala/cats/derived/hash.scala
@@ -36,6 +36,7 @@ class HashSuite extends KittensSuite {
   })
 
   test("derives an instance for Interleaved[T]") {
+    import cats.instances.all._
     semi.hash[TestDefns.Interleaved[Int]]
   }
 

--- a/core/src/test/scala/cats/derived/hash.scala
+++ b/core/src/test/scala/cats/derived/hash.scala
@@ -35,6 +35,9 @@ class HashSuite extends KittensSuite {
     }
   })
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.hash[TestDefns.Interleaved[Int]]")
+  }
 
   test("existing Hash instances in scope are respected auto")(check {
 

--- a/core/src/test/scala/cats/derived/hash.scala
+++ b/core/src/test/scala/cats/derived/hash.scala
@@ -36,7 +36,7 @@ class HashSuite extends KittensSuite {
   })
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.hash[TestDefns.Interleaved[Int]]")
+    semi.hash[TestDefns.Interleaved[Int]]
   }
 
   test("existing Hash instances in scope are respected auto")(check {

--- a/core/src/test/scala/cats/derived/iterable.scala
+++ b/core/src/test/scala/cats/derived/iterable.scala
@@ -88,4 +88,9 @@ class IterableSuite extends KittensSuite {
     val i = I.iterator
     assert(I.map(_.length).sum == 13)
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.iterable[TestDefns.Interleaved, Int]")
+  }
+
 }

--- a/core/src/test/scala/cats/derived/iterable.scala
+++ b/core/src/test/scala/cats/derived/iterable.scala
@@ -90,7 +90,10 @@ class IterableSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    semi.iterable[TestDefns.Interleaved, Int]
+    import cats.instances.all._
+    val interleaved = Interleaved(42, 313, 3.17, List(1, 2, 3, 5, 7), "kittens")
+    val i = semi.iterable[TestDefns.Interleaved, Int](interleaved)
+    assert(i.toList == List(313, 1, 2, 3, 5, 7))
   }
 
 }

--- a/core/src/test/scala/cats/derived/iterable.scala
+++ b/core/src/test/scala/cats/derived/iterable.scala
@@ -90,7 +90,7 @@ class IterableSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.iterable[TestDefns.Interleaved, Int]")
+    semi.iterable[TestDefns.Interleaved, Int]
   }
 
 }

--- a/core/src/test/scala/cats/derived/monoid.scala
+++ b/core/src/test/scala/cats/derived/monoid.scala
@@ -38,7 +38,7 @@ class MonoidSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.monoid[TestDefns.Interleaved[Int]]")
+    semi.monoid[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/monoid.scala
+++ b/core/src/test/scala/cats/derived/monoid.scala
@@ -37,6 +37,10 @@ class MonoidSuite extends KittensSuite {
     checkAll("Monoid[Rec]", MonoidTests[Rec].monoid)
   }
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.monoid[TestDefns.Interleaved[Int]]")
+  }
+
 }
 
 object MonoidSuite {

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -33,4 +33,10 @@ class MonoidKSuite extends KittensSuite {
     checkAll("AutoMonoidK[ComplexProduct]", MonoidTests[ComplexProduct[Char]].monoid)
 
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.monoidK[TestDefns.Interleaved]")
+  }
+
+
 }

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -34,9 +34,5 @@ class MonoidKSuite extends KittensSuite {
 
   }
 
-  test("derives an instance for Interleaved[T]") {
-    semi.monoidK[TestDefns.Interleaved]
-  }
-
 
 }

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -35,7 +35,7 @@ class MonoidKSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.monoidK[TestDefns.Interleaved]")
+    semi.monoidK[TestDefns.Interleaved]
   }
 
 

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -49,6 +49,11 @@ class OrderSuite extends KittensSuite {
   })
 
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.order[TestDefns.Interleaved[Int]]")
+  }
+
+
   test("existing Order instances in scope are respected for auto derivation")(check {
 
     import auto.order._

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -50,7 +50,7 @@ class OrderSuite extends KittensSuite {
 
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.order[TestDefns.Interleaved[Int]]")
+    semi.order[TestDefns.Interleaved[Int]]
   }
 
 

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -50,6 +50,7 @@ class OrderSuite extends KittensSuite {
 
 
   test("derives an instance for Interleaved[T]") {
+    import cats.instances.all._
     semi.order[TestDefns.Interleaved[Int]]
   }
 

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -48,6 +48,7 @@ class PartialOrderSuite extends KittensSuite {
   })
 
   test("derives an instance for Interleaved[T]") {
+    import cats.instances.all._
     semi.partialOrder[TestDefns.Interleaved[Int]]
   }
 

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -47,6 +47,10 @@ class PartialOrderSuite extends KittensSuite {
     }
   })
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.partialOrder[TestDefns.Interleaved[Int]]")
+  }
+
   test("existing PartialOrder instances in scope are respected for auto derivation")(check {
 
     import auto.partialOrder._

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -48,7 +48,7 @@ class PartialOrderSuite extends KittensSuite {
   })
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.partialOrder[TestDefns.Interleaved[Int]]")
+    semi.partialOrder[TestDefns.Interleaved[Int]]
   }
 
   test("existing PartialOrder instances in scope are respected for auto derivation")(check {

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -38,7 +38,7 @@ class PureSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.pure[TestDefns.Interleaved]")
+    semi.pure[TestDefns.Interleaved]
   }
 
   test("Pure[Some]") {

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -37,10 +37,6 @@ class PureSuite extends KittensSuite {
     assert(P.pure(23) == Some(23))
   }
 
-  test("derives an instance for Interleaved[T]") {
-    semi.pure[TestDefns.Interleaved]
-  }
-
   test("Pure[Some]") {
     val P = Pure[Some]
 

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -37,6 +37,10 @@ class PureSuite extends KittensSuite {
     assert(P.pure(23) == Some(23))
   }
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.pure[TestDefns.Interleaved]")
+  }
+
   test("Pure[Some]") {
     val P = Pure[Some]
 

--- a/core/src/test/scala/cats/derived/semigroup.scala
+++ b/core/src/test/scala/cats/derived/semigroup.scala
@@ -46,5 +46,8 @@ class SemigroupSuite extends KittensSuite {
   implicit val eqOuter: Eq[Outer] = Eq.fromUniversalEquals
   checkAll("Semigroup[Outer]", SemigroupTests[Outer].semigroup)
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.semigroup[TestDefns.Interleaved[Int]]")
+  }
 
 }

--- a/core/src/test/scala/cats/derived/semigroup.scala
+++ b/core/src/test/scala/cats/derived/semigroup.scala
@@ -47,7 +47,7 @@ class SemigroupSuite extends KittensSuite {
   checkAll("Semigroup[Outer]", SemigroupTests[Outer].semigroup)
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.semigroup[TestDefns.Interleaved[Int]]")
+    semi.semigroup[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -35,10 +35,6 @@ class SemigroupKSuite extends KittensSuite {
     checkAll("Auto SemigroupK[ComplexProduct]", SemigroupTests[ComplexProduct[Char]].semigroup)
   }
 
-  test("derives an instance for Interleaved[T]") {
-    semi.semigroupK[TestDefns.Interleaved]
-  }
-
 }
 
 object SemigroupKSuite {

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -34,6 +34,11 @@ class SemigroupKSuite extends KittensSuite {
     implicit val sg = SemigroupK[ComplexProduct].algebra[Char]
     checkAll("Auto SemigroupK[ComplexProduct]", SemigroupTests[ComplexProduct[Char]].semigroup)
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.semigroupK[TestDefns.Interleaved]")
+  }
+
 }
 
 object SemigroupKSuite {

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -36,7 +36,7 @@ class SemigroupKSuite extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.semigroupK[TestDefns.Interleaved]")
+    semi.semigroupK[TestDefns.Interleaved]
   }
 
 }

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -128,6 +128,10 @@ class ShowTests extends KittensSuite {
     )
   }
 
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.show[TestDefns.Interleaved[Int]]")
+  }
+
 }
 
 

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -129,7 +129,7 @@ class ShowTests extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.show[TestDefns.Interleaved[Int]]")
+    semi.show[TestDefns.Interleaved[Int]]
   }
 
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -206,4 +206,9 @@ class ShowPrettyTests extends KittensSuite {
       """.stripMargin.trim
     )
   }
+
+  test("derives an instance for Interleaved[T]") {
+    assertCompiles("semi.showPretty[TestDefns.Interleaved[Int]]")
+  }
+
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -208,7 +208,7 @@ class ShowPrettyTests extends KittensSuite {
   }
 
   test("derives an instance for Interleaved[T]") {
-    assertCompiles("semi.showPretty[TestDefns.Interleaved[Int]]")
+    semi.showPretty[TestDefns.Interleaved[Int]]
   }
 
 }


### PR DESCRIPTION
Some instances are not valid:
  - `EmptyK`: It holds a reference to a `T`, hence it cannot be empty
  - `SemigroupK`: It holds a reference to `T` which we don't know how to combine
  - `MonoidK`: This is just `EmptyK + SemigroupK`
  - `Pure`: It holds references to primitive values

Cherry-picked the first two commits from #104 

Supersedes #104 