### PR TITLE
this remove the dependencies on export hook from alleycats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
 
-addCommandAlias("validate", ";root;clean;test;mima")
+addCommandAlias("validate", ";root;clean;test") //todo: add mima back once we release 2.0
 addCommandAlias("releaseAll", ";root;release")
 addCommandAlias("js", ";project coreJS")
 addCommandAlias("jvm", ";project coreJVM")

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -16,16 +16,14 @@ object auto {
   object empty {
     implicit def kittensMkEmpty[A](
       implicit refute: Refute[Empty[A]], ev: MkEmpty[A]
-   ) : Empty[A] = ev
+    ): Empty[A] = ev
 
   }
 
-  object pure extends MkPureDerivation
-
-  object emptyK extends {
+  object emptyK {
     implicit def kittensMkEmptyK[F[_]](
       implicit refute: Refute[EmptyK[F]], ev: MkEmptyK[F]
-     ) : EmptyK[F] = ev
+     ): EmptyK[F] = ev
   }
 
   object eq {
@@ -59,7 +57,6 @@ object auto {
 
   }
 
-
   object show {
     implicit def kittensMkShow[A](
       implicit refute: Refute[Show[A]], show: MkShow[A]
@@ -72,7 +69,7 @@ object auto {
     ): ShowPretty[A] = showPretty
   }
 
-  object monoid extends MkMonoidDerivation //todo the regular approach doesn't work for monoid
+
 
   object semigroup {
     implicit def kittensMkSemigroup[A](
@@ -94,9 +91,17 @@ object auto {
     ): MonoidK[F] = ev
   }
 
-  object foldable extends MkFoldableDerivation
+  object traverse {
+    implicit def kittensMkTraverse[F[_]](
+      implicit refute: Refute[Traverse[F]], ev: MkTraverse[F]
+    ): Traverse[F] = ev
+  }
 
-  object traverse extends MkTraverseDerivation
+  //todo: the regular approach doesn't work for the following instances
+  object pure extends MkPureDerivation
+  object foldable extends MkFoldableDerivation
+  object monoid extends MkMonoidDerivation
+
 
 }
 

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -22,7 +22,11 @@ object auto {
 
   object pure extends MkPureDerivation
 
-  object emptyK extends MkEmptyKDerivation
+  object emptyK extends {
+    implicit def kittensMkEmptyK[F[_]](
+      implicit refute: Refute[EmptyK[F]], ev: MkEmptyK[F]
+     ) : EmptyK[F] = ev
+  }
 
   object eq {
     implicit def kittensMkEq[A](

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -20,6 +20,7 @@ import alleycats.EmptyK
 
 import TestDefns._
 import auto.emptyK._
+import alleycats.std.all._
 
 class EmptyKSuite extends KittensSuite {
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2-SNAPSHOT"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
this breaks BC. we can bump version to 2.0 but we still have some derivations whose auto don't respect existing instances
namely 
```
  object pure extends MkPureDerivation
  object foldable extends MkFoldableDerivation
  object monoid extends MkMonoidDerivation
```
Fixes for them probably will break BC too. I can't quickly figure out a way to fix them but on the other hand, it would be awkward if we have to bump to 3.0 once they are fixed. I don't see a great solution in terms of versioning here. 
For now, I vote for bump the version to 2.0.0-SNAPSHOT and disable mima before the 2.0 release. 