### PR TITLE
Replace usage of deprecated Applicative syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ lazy val commonSettings = Seq(
     "-feature",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-unchecked"
+    "-unchecked",
+    "-deprecation"
   ),
   scalacOptions ++= (
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/core/src/test/scala/cats/lift/LiftSuite.scala
+++ b/core/src/test/scala/cats/lift/LiftSuite.scala
@@ -15,9 +15,7 @@ class LiftSuite extends KittensSuite {
 
   test("lifting a ternary operation")(check {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val r1 = lifted(x, y, z)
-      val expected = x |@| y |@| z map foo
-      r1 == expected
+      lifted(x, y, z) == (x, y, z).mapN(foo)
     }
   })
 

--- a/core/src/test/scala/cats/sequence/TraverseHListSuite.scala
+++ b/core/src/test/scala/cats/sequence/TraverseHListSuite.scala
@@ -25,14 +25,14 @@ class TraverseHListSuite extends KittensSuite {
 
   test("traversing Set with Set => Option")(check {
     forAll { (x: Set[Int], y: Set[String], z: Set[Float]) =>
-      val expected = (x.headOption |@| y.headOption |@| z.headOption) map (_ :: _ :: _ :: HNil)
+      val expected = (x.headOption, y.headOption, z.headOption).mapN(_ :: _ :: _ :: HNil)
       (x :: y :: z :: HNil).traverse(headOption) == expected
     }
   })
 
   test("traversing Option with Option => Validation")(check {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val expected = (optToValidation(x) |@| optToValidation(y) |@| optToValidation(z)) map (_ :: _ :: _ :: HNil)
+      val expected = (optToValidation(x), optToValidation(y), optToValidation(z)).mapN(_ :: _ :: _ :: HNil)
       (x :: y :: z :: HNil).traverse(optionToValidation) == expected
     }
   })


### PR DESCRIPTION
Enable the `-deprecation` compiler flag.