### PR TITLE
Fix issues with Empty derivation for coproducts

### DIFF
--- a/core/src/main/scala/cats/derived/util/liftSome.scala
+++ b/core/src/main/scala/cats/derived/util/liftSome.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived.util
+
+import shapeless._
+
+/** Summons all available instances of the typeclass `F` for members of the coproduct `C`.
+  * Unlike `LiftAll` members of the coproduct without an instance will be skipped in the result.
+  */
+sealed trait LiftSome[F[_], C <: Coproduct] {
+  type Out <: HList
+  def instances: Out
+}
+
+object LiftSome extends LiftSomeAbsent {
+
+  implicit def liftCNil[F[_]]: Aux[F, CNil, HNil] =
+    new LiftSome[F, CNil] {
+      type Out = HNil
+      def instances = HNil
+    }
+
+  implicit def liftPresent[F[_], L, R <: Coproduct](
+    implicit F: F[L], R: LiftSome[F, R]
+  ): Aux[F, L :+: R, F[L] :: R.Out] = new LiftSome[F, L :+: R] {
+    type Out = F[L] :: R.Out
+    val instances = F :: R.instances
+  }
+}
+
+private[util] abstract class LiftSomeAbsent {
+  type Aux[F[_], C <: Coproduct, O <: HList] = LiftSome[F, C] { type Out = O }
+  def apply[F[_], C <: Coproduct](lift: LiftSome[F, C]): Aux[F, C, lift.Out] = lift
+
+  implicit def liftAbsent[F[_], L, R <: Coproduct](
+    implicit R: LiftSome[F, R]
+  ): Aux[F, L :+: R, R.Out] = new LiftSome[F, L :+: R] {
+    type Out = R.Out
+    def instances = R.instances
+  }
+}

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -24,6 +24,11 @@ import scala.annotation.tailrec
 
 object TestDefns {
 
+  sealed trait Rgb
+  case object Red extends Rgb
+  case object Green extends Rgb
+  case object Blue extends Rgb
+
   final case class ComplexProduct[T](lbl: String, set: Set[T], fns: Vector[() => T], opt: Eval[Option[T]])
   object ComplexProduct {
 

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -19,6 +19,7 @@ package derived
 
 import alleycats.Empty
 import cats.instances.all._
+import shapeless.test.illTyped
 
 class EmptySuite extends KittensSuite {
   import EmptySuite._
@@ -32,8 +33,8 @@ class EmptySuite extends KittensSuite {
     outer: Empty[Outer],
     interleaved: Empty[Interleaved[String]],
     recursive: Empty[Recursive],
-    iList: Empty[IList[Int]],
-    snoc: Empty[Snoc[String => Int]],
+    iList: Empty[IList[Dummy]],
+    snoc: Empty[Snoc[Dummy]],
     box: Empty[Box[Mask]],
     chain: Empty[Chain]
   ): Unit = {
@@ -41,8 +42,8 @@ class EmptySuite extends KittensSuite {
     test(s"$context.Empty[Outer]")(assert(outer.empty == Outer(Inner(0))))
     test(s"$context.Empty[Interleaved[String]]")(assert(interleaved.empty == Interleaved(0, "", 0, Nil, "")))
     test(s"$context.Empty[Recursive]")(assert(recursive.empty == Recursive(0, None)))
-    test(s"$context.Empty[IList[Int]]")(assert(iList.empty == INil()))
-    test(s"$context.Empty[Snoc[String => Int]]")(assert(snoc.empty == SNil()))
+    test(s"$context.Empty[IList[Dummy]]")(assert(iList.empty == INil()))
+    test(s"$context.Empty[Snoc[Dummy]]")(assert(snoc.empty == SNil()))
     test(s"$context.Empty respects existing instances")(assert(box.empty == Box(Mask(0xffffffff))))
     // Known limitation of recursive typeclass derivation.
     test(s"$context.Empty[Chain] throws a StackOverflowError")(assertThrows[StackOverflowError](chain.empty))
@@ -51,11 +52,17 @@ class EmptySuite extends KittensSuite {
   {
     import auto.empty._
     testEmpty("auto")
+    illTyped("Empty[IList[Int]]")
+    illTyped("Empty[Snoc[Int]]")
+    illTyped("Empty[Rgb]")
   }
 
   {
     import cached.empty._
     testEmpty("cached")
+    illTyped("Empty[IList[Int]]")
+    illTyped("Empty[Snoc[Int]]")
+    illTyped("Empty[Rgb]")
   }
 
   {
@@ -63,16 +70,20 @@ class EmptySuite extends KittensSuite {
     implicit val outer: Empty[Outer] = semi.empty
     implicit val interleaved: Empty[Interleaved[String]] = semi.empty
     implicit val recursive: Empty[Recursive] = semi.empty
-    implicit lazy val iList: Empty[IList[Int]] = semi.empty
-    implicit lazy val snoc: Empty[Snoc[String => Int]] = semi.empty
+    implicit lazy val iList: Empty[IList[Dummy]] = semi.empty
+    implicit lazy val snoc: Empty[Snoc[Dummy]] = semi.empty
     implicit val box: Empty[Box[Mask]] = semi.empty
     implicit lazy val chain: Empty[Chain] = semi.empty
     testEmpty("semi")
+    illTyped("semi.empty[IList[Int]]")
+    illTyped("semi.empty[Snoc[Int]]")
+    illTyped("semi.empty[Rgb]")
   }
 }
 
 object EmptySuite {
 
+  trait Dummy
   final case class Chain(head: Int, tail: Chain)
   final case class Mask(bits: Int)
   object Mask {


### PR DESCRIPTION
When deriving an `Empty` instance for coproducts we look for a
unique member of the coproduct with an `Empty` instance.

It turns out we should use `Refute` for both the left and right sides.
E.g. `IList[Int]` shouldn't work because both `Int :: HNil` and `HNil`
have `Empty` instances.