### PR TITLE
Rework Order derivation

### DIFF
--- a/core/src/main/scala/cats/derived/order.scala
+++ b/core/src/main/scala/cats/derived/order.scala
@@ -19,48 +19,37 @@ package cats.derived
 import cats.Order
 import shapeless._
 
-trait MkOrder[T] extends Order[T]
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Could not derive an instance of Order[${A}]")
+trait MkOrder[A] extends Order[A]
 
 object MkOrder extends MkOrderDerivation {
-  def apply[T](implicit met: MkOrder[T]): MkOrder[T] = met
+  def apply[A](implicit ev: MkOrder[A]): MkOrder[A] = ev
 }
 
 private[derived] abstract class MkOrderDerivation {
-  implicit val mkOrderHnil: MkOrder[HNil] =
-    new MkOrder[HNil] {
-      override def compare(x: HNil, y: HNil): Int = 0
-    }
+  implicit val mkOrderHNil: MkOrder[HNil] = instance((_, _) => 0)
+  implicit val mkOrderCNil: MkOrder[CNil] = instance((_, _) => 0)
 
-  // Compare product from left to right
-  implicit def mkOrderHcons[H, T <: HList](implicit ordH: Order[H] OrElse MkOrder[H], ordT: MkOrder[T]): MkOrder[H :: T] =
-    new MkOrder[H :: T] {
-      override def compare(x: H :: T, y: H :: T): Int = {
-        val compareHead = ordH.unify.compare(x.head, y.head)
-        if(compareHead != 0)
-          compareHead
-        else
-          ordT.compare(x.tail, y.tail)
-      }
-    }
-  implicit val mkOrderCnil: MkOrder[CNil] =
-    new MkOrder[CNil] {
-      override def compare(x: CNil, y: CNil): Int = 0
-    }
-
-  implicit def mkOrderCcons[L, R <: Coproduct](implicit ordL: Order[L] OrElse MkOrder[L], ordR: MkOrder[R]): MkOrder[L :+: R] = new MkOrder[L :+: R] {
-    def compare(x: L :+: R, y: L :+: R): Int = {
-      (x, y) match {
-        case (Inl(l1), Inl(l2)) => ordL.unify.compare(l1, l2)
-        case (Inr(r1), Inr(r2)) => ordR.compare(r1, r2)
-        case (Inl(_), Inr(_)) => -1
-        case _  => 1
-      }
-    }
+  implicit def mkOrderHCons[H, T <: HList](
+    implicit H: Order[H] OrElse MkOrder[H], T: MkOrder[T]
+  ): MkOrder[H :: T] = instance { case (hx :: tx, hy :: ty) =>
+    val cmpH = H.unify.compare(hx, hy)
+    if (cmpH != 0) cmpH else T.compare(tx, ty)
   }
 
+  implicit def mkOrderCCons[L](implicit L: Order[L] OrElse MkOrder[L]): MkOrder[L :+: CNil] =
+    instance {
+      case (Inl(lx), Inl(ly)) => L.unify.compare(lx, ly)
+      case _ => 0
+    }
 
-  implicit def mkOrderGeneric[T, R](implicit gen: Generic.Aux[T, R], ordR: Lazy[MkOrder[R]]): MkOrder[T] =
-    new MkOrder[T] {
-      override def compare(x: T, y: T): Int = ordR.value.compare(gen.to(x), gen.to(y))
+  implicit def mkOrderGeneric[A, R](implicit A: Generic.Aux[A, R], R: Lazy[MkOrder[R]]): MkOrder[A] =
+    instance((x, y) => R.value.compare(A.to(x), A.to(y)))
+
+  private def instance[A](f: (A, A) => Int): MkOrder[A] =
+    new MkOrder[A] {
+      def compare(x: A, y: A) = f(x, y)
     }
 }

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -40,8 +40,8 @@ object auto {
 
   object order {
     implicit def kittensMkOrder[A](
-      implicit refute: Refute[Order[A]], ord: MkOrder[A]
-    ): Order[A] = ord
+      implicit refute: Refute[Order[A]], ev: Lazy[MkOrder[A]]
+    ): Order[A] = ev.value
   }
 
   object hash {
@@ -168,8 +168,8 @@ object cached {
 
   object order {
     implicit def kittensMkOrder[A](
-       implicit refute: Refute[Order[A]], ord: Cached[MkOrder[A]])
-    : Order[A] = ord.value
+      implicit refute: Refute[Order[A]], cached: Cached[MkOrder[A]]
+    ): Order[A] = cached.value
   }
 
   object hash {
@@ -292,7 +292,7 @@ object semi {
 
   def partialOrder[A](implicit ev: Lazy[MkPartialOrder[A]]): PartialOrder[A] = ev.value
 
-  def order[A](implicit ev: MkOrder[A]): Order[A] = ev
+  def order[A](implicit ev: Lazy[MkOrder[A]]): Order[A] = ev.value
 
   def hash[A](implicit ev: MkHash[A]): Hash[A] = ev
 

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -63,6 +63,9 @@ object TestDefns {
 
     implicit def arbitrary[A: Arbitrary]: Arbitrary[Box[A]] =
       Arbitrary(Arbitrary.arbitrary[A].map(apply))
+
+    implicit def cogen[A: Cogen]: Cogen[Box[A]] =
+      Cogen[A].contramap(_.content)
   }
 
   final case class Recursive(i: Int, is: Option[Recursive])
@@ -250,6 +253,9 @@ object TestDefns {
 
     implicit def arbitrary[A: Arbitrary]: Arbitrary[GenericAdt[A]] =
       Arbitrary(Arbitrary.arbitrary[Option[A]].map(GenericAdtCase.apply))
+
+    implicit def cogen[A: Cogen]: Cogen[GenericAdt[A]] =
+      Cogen[Option[A]].contramap({ case GenericAdtCase(value) => value })
   }
 
   final case class CaseClassWOption[A](value: Option[A])

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -32,7 +32,6 @@ class PartialOrderSuite extends KittensSuite {
     interleaved: PartialOrder[Interleaved[Int]],
     tree: PartialOrder[Tree[Int]],
     recursive: PartialOrder[Recursive],
-    large: PartialOrder[Large4],
     boxKeyValue: PartialOrder[Box[KeyValue]]
   ): Unit = {
     checkAll(s"$context.PartialOrder[IList[Int]]", PartialOrderTests[IList[Int]].partialOrder)
@@ -41,7 +40,7 @@ class PartialOrderSuite extends KittensSuite {
     checkAll(s"$context.PartialOrder[Interleaved[Int]]", PartialOrderTests[Interleaved[Int]].partialOrder)
     checkAll(s"$context.PartialOrder[Tree[Int]]", PartialOrderTests[Tree[Int]].partialOrder)
     checkAll(s"$context.PartialOrder[Recursive]", PartialOrderTests[Recursive].partialOrder)
-    checkAll(s"$context.PartialOrder[Box[KeyValue]]", PartialOrderTests[Interleaved[Int]].partialOrder)
+    checkAll(s"$context.PartialOrder[Box[KeyValue]]", PartialOrderTests[Box[KeyValue]].partialOrder)
 
     test(s"$context.PartialOrder respects existing instances") {
       val x = Box(KeyValue("red", 1))
@@ -71,7 +70,6 @@ class PartialOrderSuite extends KittensSuite {
     implicit val interleaved: PartialOrder[Interleaved[Int]] = semi.partialOrder
     implicit val tree: PartialOrder[Tree[Int]] = semi.partialOrder
     implicit val recursive: PartialOrder[Recursive] = semi.partialOrder
-    implicit val large: PartialOrder[Large4] = semi.partialOrder
     implicit val boxKeyValue: PartialOrder[Box[KeyValue]] = semi.partialOrder
     def run(): Unit = testPartialOrder("semi")
   }
@@ -85,6 +83,6 @@ object PartialOrderSuite {
     implicit val cogen: Cogen[KeyValue] = Cogen[(String, Int)].contramap(unapply(_).get)
 
     implicit val partialOrder: PartialOrder[KeyValue] =
-      PartialOrder.from((x, y) => if (x.key == y.key) x.value - y.value else Double.NaN)
+      PartialOrder.from((x, y) => if (x.key == y.key) x.value.toDouble - y.value.toDouble else Double.NaN)
   }
 }


### PR DESCRIPTION
  * Make it more consistent with other derivations
  * Add more tests and remove `LargeX` compile test:
    Testing compile time performance is better done in a benchmark.

  * Drop derivation for coproducts with more than one case:
    It's ambiguous and inconsistent with `PartialOrder` derivation.