### PR TITLE
Scala 2.13.0 and Hash derivation rework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
 - 2.12.8
 - 2.11.12
-- 2.13.0-M5
+- 2.13.0
 
 jdk:
 - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,11 @@ import sbtcrossproject.{CrossType, crossProject}
 
 lazy val buildSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.0-M5")
+  scalaVersion := "2.13.0",
+  crossScalaVersions := Seq("2.11.12", "2.12.8", scalaVersion.value)
 )
 
-val catsVersion = "1.6.0"
+val catsVersion = "2.0.0-M4"
 
 lazy val commonSettings = Seq(
   scalacOptions := Seq(
@@ -22,11 +22,8 @@ lazy val commonSettings = Seq(
   ),
   scalacOptions ++= (
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v <= 12 => Seq(
-        "-Ypartial-unification"
-      )
-      case _ => Seq(
-      )
+      case Some((2, v)) if v <= 12 => Seq("-Ypartial-unification")
+      case _ => Seq.empty
     }
   ),
   resolvers ++= Seq(
@@ -39,7 +36,7 @@ lazy val commonSettings = Seq(
     "org.typelevel"   %% "alleycats-core" % catsVersion,
     "com.chuusai"     %% "shapeless"      % "2.3.3",
     "org.typelevel"   %% "cats-testkit"   % catsVersion % "test",
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
+    compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
   ),
   scmInfo :=
     Some(ScmInfo(

--- a/core/src/main/scala-2.11/cats/derived/util/versionspecific.scala
+++ b/core/src/main/scala-2.11/cats/derived/util/versionspecific.scala
@@ -1,0 +1,7 @@
+package cats.derived.util
+
+import scala.util.hashing.MurmurHash3
+
+private[derived] object VersionSpecific {
+  def productSeed(x: Product): Int = MurmurHash3.productSeed
+}

--- a/core/src/main/scala-2.12/cats/derived/util/versionspecific.scala
+++ b/core/src/main/scala-2.12/cats/derived/util/versionspecific.scala
@@ -1,0 +1,7 @@
+package cats.derived.util
+
+import scala.util.hashing.MurmurHash3
+
+private[derived] object VersionSpecific {
+  def productSeed(x: Product): Int = MurmurHash3.productSeed
+}

--- a/core/src/main/scala-2.13/cats/derived/util/versionspecific.scala
+++ b/core/src/main/scala-2.13/cats/derived/util/versionspecific.scala
@@ -1,0 +1,7 @@
+package cats.derived.util
+
+import scala.util.hashing.MurmurHash3
+
+private[derived] object VersionSpecific {
+  def productSeed(x: Product): Int = MurmurHash3.mix(MurmurHash3.productSeed, x.productPrefix.hashCode)
+}

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -46,8 +46,8 @@ object auto {
 
   object hash {
     implicit def kittensMkHash[A](
-      implicit refute: Refute[Hash[A]], hash: MkHash[A]
-    ): Hash[A] = hash
+      implicit refute: Refute[Hash[A]], ev: Lazy[MkHash[A]]
+    ): Hash[A] = ev.value
   }
 
   object functor {
@@ -174,8 +174,8 @@ object cached {
 
   object hash {
     implicit def kittensMkHash[A](
-       implicit refute: Refute[Hash[A]], ord: Cached[MkHash[A]])
-    : Hash[A] = ord.value
+      implicit refute: Refute[Hash[A]], cached: Cached[MkHash[A]]
+    ): Hash[A] = cached.value
   }
 
   object functor {
@@ -294,7 +294,7 @@ object semi {
 
   def order[A](implicit ev: Lazy[MkOrder[A]]): Order[A] = ev.value
 
-  def hash[A](implicit ev: MkHash[A]): Hash[A] = ev
+  def hash[A](implicit ev: Lazy[MkHash[A]]): Hash[A] = ev.value
 
   def functor[F[_]](implicit F: Lazy[MkFunctor[F]]): Functor[F] = F.value
 

--- a/core/src/test/scala/cats/derived/KittensSuite.scala
+++ b/core/src/test/scala/cats/derived/KittensSuite.scala
@@ -17,7 +17,7 @@
 package cats.derived
 
 import cats.syntax.AllSyntax
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 import scala.util.control.NonFatal
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
  * CatsSuite in the Cat project, this trait does not mix in any
  * instances.
  */
-trait KittensSuite extends FunSuite with Discipline with AllSyntax with SerializableTest
+trait KittensSuite extends AnyFunSuite with Discipline with AllSyntax with SerializableTest
 
 
 trait SerializableTest {

--- a/core/src/test/scala/cats/derived/consk.scala
+++ b/core/src/test/scala/cats/derived/consk.scala
@@ -17,14 +17,13 @@
 package cats.derived
 
 import alleycats.ConsK
-import org.scalacheck.Arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.prop.{Generator, GeneratorDrivenPropertyChecks}
 
 class ConsKSuite extends KittensSuite with GeneratorDrivenPropertyChecks {
   import TestDefns._
 
-  def checkConsK[F[_], A: Arbitrary](nil: F[A])(fromSeq: Seq[A] => F[A])(implicit F: ConsK[F]): Unit =
-    forAll((xs: Seq[A]) => assert(xs.foldRight(nil)(F.cons) == fromSeq(xs)))
+  def checkConsK[F[_], A: Generator](nil: F[A])(fromSeq: Seq[A] => F[A])(implicit F: ConsK[F]): Unit =
+    forAll((xs: List[A]) => assert(xs.foldRight(nil)(F.cons) == fromSeq(xs)))
 
   def testConsK(context: String)(implicit iList: ConsK[IList], snoc: ConsK[Snoc]): Unit = {
     test(s"$context.ConsK[IList]")(checkConsK[IList, Int](INil())(IList.fromSeq))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.github.gseitz"                 % "sbt-release"            % "1.0.11")
 addSbtPlugin("com.jsuereth"                      % "sbt-pgp"                % "1.1.2")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"                % "1.0.0")
-addSbtPlugin("org.scala-js"                      % "sbt-scalajs"            % "0.6.27")
+addSbtPlugin("org.scala-js"                      % "sbt-scalajs"            % "0.6.28")
 addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"           % "2.4")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"       % "3.0.0")
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
Case classes' `hashCode` is not backwards compatible in Scala 2.13,
because it mixes the `productPrefix` for better distribution.
This means we need version specific code to pass the `Hash` laws.

  * Update dependencies for Scala 2.13.0
  * Rework `Hash` derivation for consistency
  * Split product and coproduct derivation
  * Add a Scala version specific seed for `scala.Product` subtypes
  * Optimize `HashBuilder` to a one-pass hash
  * Replace usages of `Statics` (not recommended) with `MurmurHash3`
  * Test all variants of `Hash` derivation