### PR TITLE
Refactor sequence and traverse implementations

### DIFF
--- a/core/src/main/scala/cats/sequence/package.scala
+++ b/core/src/main/scala/cats/sequence/package.scala
@@ -1,2 +1,3 @@
 package cats
+
 package object sequence extends SequenceOps with TraverseOps

--- a/core/src/main/scala/cats/sequence/sequence.scala
+++ b/core/src/main/scala/cats/sequence/sequence.scala
@@ -5,152 +5,127 @@
  */
 package cats.sequence
 
-import shapeless._
 import cats.{Applicative, Apply, Functor}
+import shapeless._
 import shapeless.ops.hlist.{Align, ZipWithKeys}
-import shapeless.ops.record.{Keys, Values}
+import shapeless.ops.record.{Keys, UnzipFields}
 
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("cannot construct sequencer, make sure that every item of your hlist ${L} is an Apply")
-trait Sequencer[L <: HList]  extends Serializable {
+trait Sequencer[L <: HList] extends Serializable {
   type F[_]
   type LOut <: HList
   type Out = F[LOut]
-  def apply(in: L): Out
+  def apply(hl: L): Out
 }
 
-trait LowPrioritySequencer {
+private[sequence] abstract class MkHConsSequencer {
+
   type Aux[L <: HList, F0[_], LOut0] = Sequencer[L] {
     type F[X] = F0[X]
     type LOut = LOut0
   }
 
-  implicit def consSequencerAux[A[_], H, TF <: HList, T <: HList]
-    (implicit st: Aux[TF, A, T], A: Apply[A]): Aux[A[H] :: TF, A, H :: T] =
-      new Sequencer[A[H] :: TF] {
-        type F[X] = A[X]
-        type LOut = H :: T
-
-        def apply(in: F[H] :: TF): A[LOut] = {
-          A.map2(in.head, st(in.tail))(_ :: _)
-        }
-      }
+  implicit def mkHConsSequencer[F0[_], H, FT <: HList, T <: HList](
+    implicit tailSequencer: Aux[FT, F0, T], F: Apply[F0]
+  ): Aux[F0[H] :: FT, F0, H :: T] = new Sequencer[F0[H] :: FT] {
+    type F[X] = F0[X]
+    type LOut = H :: T
+    def apply(hl: F[H] :: FT) = F.map2(hl.head, tailSequencer(hl.tail))(_ :: _)
+  }
 }
 
-object Sequencer extends LowPrioritySequencer {
+object Sequencer extends MkHConsSequencer {
 
-  implicit def emptySequencerAux[F0[_], H](implicit F: Applicative[F0])
-    : Aux[HNil, F0, HNil] =
-      new Sequencer[HNil] {
-        type F[X] = F0[X]
-        type LOut = HNil
+  implicit def mkHNilSequencer[F0[_]](
+    implicit F: Applicative[F0]
+  ): Aux[HNil, F0, HNil] = new Sequencer[HNil] {
+    type F[X] = F0[X]
+    type LOut = HNil
+    def apply(nil: HNil) = F.pure(nil)
+  }
 
-        def apply(in: HNil): F[HNil] = F.pure(HNil)
-      }
-
-  implicit def singleSequencerAux[F0[_], H](implicit F: Functor[F0])
-    : Aux[F0[H] :: HNil, F0, H :: HNil] =
-      new Sequencer[F0[H] :: HNil] {
-        type F[X] = F0[X]
-        type LOut = H :: HNil
-
-        def apply(in: F[H] :: HNil): F[LOut] = F.map(in.head) {
-          _ :: HNil
-        }
-      }
+  implicit def mkSingletonSequencer[F0[_], H](
+    implicit F: Functor[F0]
+  ): Aux[F0[H] :: HNil, F0, H :: HNil] = new Sequencer[F0[H] :: HNil] {
+    type F[X] = F0[X]
+    type LOut = H :: HNil
+    def apply(singleton: F[H] :: HNil) = F.map(singleton.head)(_ :: HNil)
+  }
 }
-
 
 @implicitNotFound("cannot construct sequencer, make sure that every field value of you record ${L} is an Apply")
 trait RecordSequencer[L <: HList] extends Serializable {
   type Out
-
-  def apply(in: L): Out
+  def apply(record: L): Out
 }
 
-
-object RecordSequencer extends MkRecordSequencer {
+object RecordSequencer {
   type Aux[L <: HList, Out0] = RecordSequencer[L] { type Out = Out0 }
+
+  implicit def mkRecordSequencer[R <: HList, K <: HList, V <: HList, F[_], VOut <: HList](
+    implicit unzip: UnzipFields.Aux[R, K, V],
+    valueSequencer: Sequencer.Aux[V, F, VOut],
+    F: Functor[F],
+    zip: ZipWithKeys[K, VOut]
+  ): RecordSequencer.Aux[R, F[zip.Out]] = new RecordSequencer[R] {
+    type Out = F[zip.Out]
+    def apply(record: R) = F.map(valueSequencer(unzip.values(record)))(zip(_))
+  }
 }
-
-trait MkRecordSequencer {
-  implicit def mkRecordSequencer[R <: HList, K <: HList, V <: HList, F[_], VOut <: HList]
-  ( implicit
-    V: Values.Aux[R, V],
-    K: Keys.Aux[R, K],
-    vSequencer: Sequencer.Aux[V, F, VOut],
-    zip: ZipWithKeys[K, VOut],
-    F: Functor[F]
-  ): RecordSequencer.Aux[R, F[zip.Out]] =
-    new RecordSequencer[R] {
-      type Out = F[zip.Out]
-
-      def apply(in: R): Out = {
-        F.map(vSequencer(V(in)))(zip(_))
-      }
-    }
-}
-
 
 trait GenericSequencer[L <: HList, T] extends Serializable {
   type Out
-  def apply(l: L): Out
+  def apply(hl: L): Out
 }
 
-object GenericSequencer extends MkGenericSequencer {
+object GenericSequencer {
   type Aux[L <: HList, T, Out0] = GenericSequencer[L, T] { type Out = Out0 }
-}
 
-trait MkGenericSequencer {
-
-  implicit def mkGenericSequencer[L <: HList, T, SOut <: HList, FOut, LOut <: HList, F[_]]
-  ( implicit
-    rs: RecordSequencer.Aux[L, FOut],
-    gen: LabelledGeneric.Aux[T, LOut],
+  implicit def mkGenericSequencer[L <: HList, T, SOut <: HList, FOut, LOut <: HList, F[_]](
+    implicit recordSequencer: RecordSequencer.Aux[L, FOut],
     eqv: FOut =:= F[SOut],
-    align: Align[SOut, LOut],
-    F: Functor[F]
-  ): GenericSequencer.Aux[L, T, F[T]] =
-    new GenericSequencer[L, T] {
-      type Out = F[T]
-
-      def apply(in: L): Out = {
-        F.map(rs(in))(l => gen.from(l.align))
-      }
-    }
+    F: Functor[F],
+    gen: LabelledGeneric.Aux[T, LOut],
+    align: Align[SOut, LOut]
+  ): GenericSequencer.Aux[L, T, F[T]] = new GenericSequencer[L, T] {
+    type Out = F[T]
+    def apply(hl: L) = F.map(recordSequencer(hl))(so => gen.from(so.align))
+  }
 }
 
-
-trait LowPrioritySequenceOps {
+private[sequence] trait MkNonRecordOps {
   import SequenceOps._
+
   // fallback for non-records
-  implicit def mkNonRecordOps[L <: HList](l: L): NonRecordOps[L] = new NonRecordOps(l)
+  implicit def mkNonRecordOps[L <: HList](hl: L): NonRecordOps[L] =
+    new NonRecordOps(hl)
 }
 
-
-trait SequenceOps extends LowPrioritySequenceOps {
+trait SequenceOps extends MkNonRecordOps {
   import SequenceOps._
-  implicit def mkRecordOps[L <: HList](l: L)
-                                      (implicit keys: Keys[L]): RecordOps[L] = new RecordOps(l)
+
+  implicit def mkRecordOps[L <: HList: Keys](hl: L): RecordOps[L] =
+    new RecordOps(hl)
 
   object sequence extends ProductArgs {
-    def applyProduct[L <: HList](l: L)(implicit seq: Sequencer[L]): seq.Out = seq(l)
+    def applyProduct[L <: HList](hl: L)(implicit seq: Sequencer[L]): seq.Out = seq(hl)
   }
 
   object sequenceRecord extends RecordArgs {
-    def applyRecord[L <: HList](l: L)(implicit seq: RecordSequencer[L]): seq.Out = seq(l)
+    def applyRecord[L <: HList](hl: L)(implicit seq: RecordSequencer[L]): seq.Out = seq(hl)
   }
 
   class sequenceGen[T] extends RecordArgs {
-    def applyRecord[L <: HList](l: L)(implicit seq: GenericSequencer[L, T]): seq.Out = seq(l)
+    def applyRecord[L <: HList](hl: L)(implicit seq: GenericSequencer[L, T]): seq.Out = seq(hl)
   }
 
   def sequenceGeneric[T] = new sequenceGen[T]
-
 }
 
 object SequenceOps {
+
   // Syntax for non-records
   class NonRecordOps[L <: HList](self: L) {
     def sequence(implicit seq: Sequencer[L]): seq.Out = seq(self)
@@ -160,5 +135,4 @@ object SequenceOps {
   class RecordOps[L <: HList](self: L) {
     def sequence(implicit seq: RecordSequencer[L]): seq.Out = seq(self)
   }
-
 }

--- a/core/src/main/scala/cats/sequence/traverse.scala
+++ b/core/src/main/scala/cats/sequence/traverse.scala
@@ -10,32 +10,28 @@ import shapeless.ops.hlist._
 
 sealed trait Traverser[L <: HList, P] extends Serializable {
   type Out
-  def apply(in: L): Out
+  def apply(hl: L): Out
 }
 
 object Traverser {
   type Aux[L <: HList, P, Out0] = Traverser[L, P] { type Out = Out0 }
 
   implicit def mkTraverser[L <: HList, P, S <: HList](
-    implicit
-      mapper: Mapper.Aux[P, L, S],
-      sequencer: Sequencer[S]
-  ): Aux[L, P, sequencer.Out] =
-    new Traverser[L, P] {
-      type Out = sequencer.Out
-      def apply(in: L): Out = sequencer(mapper(in))
-    }
+    implicit mapper: Mapper.Aux[P, L, S], sequencer: Sequencer[S]
+  ): Aux[L, P, sequencer.Out] = new Traverser[L, P] {
+    type Out = sequencer.Out
+    def apply(hl: L): Out = sequencer(mapper(hl))
+  }
 }
 
 trait TraverseFunctions {
-  def traverse[L <: HList](in: L)(f: Poly)
-    (implicit traverser: Traverser[L, f.type]): traverser.Out = traverser(in)
-
+  def traverse[L <: HList](hl: L)(f: Poly)(implicit traverser: Traverser[L, f.type]): traverser.Out =
+    traverser(hl)
 }
 
 trait TraverseOps extends {
   implicit class withTraverse[L <: HList](self: L) {
-    def traverse(f: Poly)
-      (implicit traverser: Traverser[L, f.type]): traverser.Out = traverser(self)
+    def traverse(f: Poly)(implicit traverser: Traverser[L, f.type]): traverser.Out =
+      traverser(self)
   }
 }

--- a/core/src/test/scala/cats/sequence/SequenceSuite.scala
+++ b/core/src/test/scala/cats/sequence/SequenceSuite.scala
@@ -156,10 +156,8 @@ class SequenceSuite extends KittensSuite {
     assert(f.run("42.0") == Some(MyCase(4, "0.24", 42.0f)))
   }
 
-  //wait until cats 0.5.0 release to bring unapply to serializable
   test("RecordSequencer is serializable") {
-    val r = Record.`'a -> Option[Int], 'b -> Option[String]`
-    type Rec = r.T
+    type Rec = Record.`'a -> Option[Int], 'b -> Option[String]`.T
     val rs = the[RecordSequencer[Rec]]
     assert(isSerializable(rs))
   }

--- a/core/src/test/scala/cats/sequence/TraverseHListSuite.scala
+++ b/core/src/test/scala/cats/sequence/TraverseHListSuite.scala
@@ -4,16 +4,15 @@
 package cats.sequence
 
 import cats.data._
-import cats.instances.all._
-
-import shapeless._
 import cats.derived._
+import cats.instances.all._
 import org.scalacheck.Prop.forAll
-
+import shapeless._
 
 class TraverseHListSuite extends KittensSuite {
 
-  def optToValidation[T](opt: Option[T]): Validated[String, T] = Validated.fromOption(opt, "Nothing Here")
+  def optToValidation[T](opt: Option[T]): Validated[String, T] =
+    Validated.fromOption(opt, "Nothing Here")
 
   object headOption extends Poly1 {
     implicit def caseSet[T] = at[Set[T]](_.headOption)
@@ -36,5 +35,4 @@ class TraverseHListSuite extends KittensSuite {
       (x :: y :: z :: HNil).traverse(optionToValidation) == expected
     }
   })
-
 }


### PR DESCRIPTION
  * Remove some unnecessarsy prioritizatoin traits
  * Make other prioritization traits `private[sequence]`
  * Remove free type parameter in `mkHNilSequencer`
  * Use `UnzipFields` instead of `Keys` and `Values`
  * Naming and formatting changes