### PR TITLE
Add Gen.delay to Arbitrary[Recursive]

### DIFF
--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -56,7 +56,7 @@ object TestDefns {
   object Recursive extends ((Int, Option[Recursive]) => Recursive) {
 
     implicit val arbitrary: Arbitrary[Recursive] =
-      Arbitrary(Arbitrary.arbitrary[(Int, Option[Recursive])].map(tupled))
+      Arbitrary(Gen.delay(Arbitrary.arbitrary[(Int, Option[Recursive])]).map(tupled))
 
     implicit val cogen: Cogen[Recursive] =
       Cogen[(Int, Option[Recursive])].contramap(unapply(_).get)

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -56,7 +56,7 @@ object TestDefns {
   object Recursive extends ((Int, Option[Recursive]) => Recursive) {
 
     implicit val arbitrary: Arbitrary[Recursive] =
-      Arbitrary(Gen.delay(Arbitrary.arbitrary[(Int, Option[Recursive])]).map(tupled))
+      Arbitrary(Gen.delay(Arbitrary.arbitrary[(Int, Option[Recursive])].map(tupled)))
 
     implicit val cogen: Cogen[Recursive] =
       Cogen[(Int, Option[Recursive])].contramap(unapply(_).get)


### PR DESCRIPTION
ScalaCheck will simplify its implementation of `Arbitrary[Option]` in the next release 1.14.1, but the change incidentally increases the probability of a stackoverflow for recursive data types with `Option`.

I've tested this with a local snapshot of ScalaCheck.

https://github.com/typelevel/scalacheck/issues/488