### PR TITLE
Fix master

### DIFF
--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -32,7 +32,7 @@ class FunctorSuite extends KittensSuite {
   type NestedPred[A] = Pred[Pred[A]]
 
   implicit val exhaustivePred: ExhaustiveCheck[Pred[Boolean]] =
-    ExhaustiveCheck.instance(Stream(_ => true, _ => false, identity, !_))
+    ExhaustiveCheck.instance(List(_ => true, _ => false, identity, !_))
 
   def testFunctor(context: String)(
     implicit iList: Functor[IList],


### PR DESCRIPTION
`ExhaustiveCheck.instance` is now based on a `List`.

Looks like a semantic merge conflict between #178 and #179 