### PR TITLE
Improve implicitNotFound messages

### DIFF
--- a/core/src/main/scala/cats/derived/applicative.scala
+++ b/core/src/main/scala/cats/derived/applicative.scala
@@ -22,7 +22,15 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Applicative[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Applicative[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T] where T: Monoid
+  * it is a nested type λ[x => G[H[x]]] where G: Applicative and H: Applicative
+  * it is a generic case class where all fields have an Applicative instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkApplicative[F[_]] extends Applicative[F]
 
 object MkApplicative extends MkApplicativeDerivation {

--- a/core/src/main/scala/cats/derived/apply.scala
+++ b/core/src/main/scala/cats/derived/apply.scala
@@ -22,7 +22,15 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Apply[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Apply[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T] where T: Semigroup
+  * it is a nested type λ[x => G[H[x]]] where G: Apply and H: Apply
+  * it is a generic case class where all fields have an Apply instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkApply[F[_]] extends Apply[F]
 
 object MkApply extends MkApplyDerivation {

--- a/core/src/main/scala/cats/derived/contravariant.scala
+++ b/core/src/main/scala/cats/derived/contravariant.scala
@@ -22,7 +22,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Contravariant[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Contravariant[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T]
+  * it is a nested type λ[x => G[H[x]]] where G: Functor and H: Contravariant
+  * it is a generic case class where all fields have a Contravariant instance
+  * it is a generic sealed trait where all subclasses have a Contravariant instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkContravariant[F[_]] extends Contravariant[F] {
   def safeContramap[A, B](fa: F[A])(f: B => Eval[A]): Eval[F[B]]
   def contramap[A, B](fa: F[A])(f: B => A): F[B] = safeContramap(fa)((b: B) => Eval.later(f(b))).value

--- a/core/src/main/scala/cats/derived/empty.scala
+++ b/core/src/main/scala/cats/derived/empty.scala
@@ -23,7 +23,12 @@ import util.VersionSpecific.{OrElse, Lazy}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Empty[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Empty[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have an Empty instance
+  * it is a sealed trait where exactly one subclass has an Empty instance
+""".trim)
 trait MkEmpty[A] extends Empty[A]
 
 object MkEmpty extends MkEmptyDerivation {

--- a/core/src/main/scala/cats/derived/emptyk.scala
+++ b/core/src/main/scala/cats/derived/emptyk.scala
@@ -22,7 +22,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of EmptyK[${F}]")
+@implicitNotFound("""
+Could not derive an instance of EmptyK[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T] where T: Empty
+  * it is a nested type λ[x => G[H[x]]] where G: EmptyK
+  * it is a nested type λ[x => G[H[x]]] where G: Pure and H: EmptyK
+  * it is a generic case class where all fields have an EmptyK instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkEmptyK[F[_]] extends EmptyK[F]
 
 object MkEmptyK extends MkEmptyKDerivation {

--- a/core/src/main/scala/cats/derived/eq.scala
+++ b/core/src/main/scala/cats/derived/eq.scala
@@ -22,7 +22,12 @@ import util.VersionSpecific.{OrElse, Lazy}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Eq[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Eq[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have an Eq instance
+  * it is a sealed trait where all subclasses have an Eq instance
+""".trim)
 trait MkEq[A] extends Eq[A]
 
 object MkEq extends MkEqDerivation {

--- a/core/src/main/scala/cats/derived/foldable.scala
+++ b/core/src/main/scala/cats/derived/foldable.scala
@@ -22,7 +22,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Foldable[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Foldable[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T]
+  * it is a nested type λ[x => G[H[x]]] where G: Foldable and H: Foldable
+  * it is a generic case class where all fields have a Foldable instance
+  * it is a generic sealed trait where all subclasses have a Foldable instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkFoldable[F[_]] extends Foldable[F] {
   def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B]
   def safeFoldLeft[A, B](fa: F[A], b: B)(f: (B, A) => Eval[B]): Eval[B]

--- a/core/src/main/scala/cats/derived/functor.scala
+++ b/core/src/main/scala/cats/derived/functor.scala
@@ -22,7 +22,17 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Functor[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Functor[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T]
+  * it is a nested type λ[x => G[H[x]]] where G: Functor and H: Functor
+  * it is a nested type λ[x => G[H[x]]] where G: Contravariant and H: Contravariant
+  * it is a generic case class where all fields have a Functor instance
+  * it is a generic sealed trait where all subclasses have a Functor instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkFunctor[F[_]] extends Functor[F] {
   def safeMap[A, B](fa: F[A])(f: A => Eval[B]): Eval[F[B]]
 

--- a/core/src/main/scala/cats/derived/hash.scala
+++ b/core/src/main/scala/cats/derived/hash.scala
@@ -4,7 +4,12 @@ package derived
 import scala.annotation.{implicitNotFound, tailrec}
 import scala.util.hashing.MurmurHash3
 
-@implicitNotFound("Could not derive an instance of Hash[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Hash[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have a Hash instance
+  * it is a sealed trait where all subclasses have a Hash instance
+""".trim)
 trait MkHash[A] extends Hash[A]
 
 object MkHash extends MkHashDerivation {

--- a/core/src/main/scala/cats/derived/invariant.scala
+++ b/core/src/main/scala/cats/derived/invariant.scala
@@ -22,7 +22,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Invariant[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Invariant[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T]
+  * it is a nested type λ[x => G[H[x]]] where G: Invariant and H: Invariant
+  * it is a generic case class where all fields have an Invariant instance
+  * it is a generic sealed trait where all subclasses have an Invariant instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkInvariant[F[_]] extends Invariant[F] {
   def safeImap[A, B](fa: F[A])(g: A => Eval[B])(f: B => Eval[A]): Eval[F[B]]
   def imap[A, B](fa: F[A])(g: A => B)(f: B => A): F[B] =

--- a/core/src/main/scala/cats/derived/monoid.scala
+++ b/core/src/main/scala/cats/derived/monoid.scala
@@ -22,7 +22,10 @@ import util.VersionSpecific.{OrElse, Lazy}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Monoid[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Monoid[A] where A = ${A}.
+Make sure that A is a case class where all fields have a Monoid instance.
+""".trim)
 trait MkMonoid[A] extends Monoid[A]
 
 object MkMonoid extends MkMonoidDerivation {

--- a/core/src/main/scala/cats/derived/monoidk.scala
+++ b/core/src/main/scala/cats/derived/monoidk.scala
@@ -22,7 +22,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of MonoidK[${F}]")
+@implicitNotFound("""
+Could not derive an instance of MonoidK[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T] where T: Monoid
+  * it is a nested type λ[x => G[H[x]]] where G: MonoidK
+  * it is a nested type λ[x => G[H[x]]] where G: Applicative and H: MonoidK
+  * it is a generic case class where all fields have a MonoidK instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkMonoidK[F[_]] extends MonoidK[F]
 
 object MkMonoidK extends MkMonoidKDerivation {

--- a/core/src/main/scala/cats/derived/order.scala
+++ b/core/src/main/scala/cats/derived/order.scala
@@ -22,7 +22,12 @@ import util.VersionSpecific.{OrElse, Lazy}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Order[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Order[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have an Order instance
+  * it is a sealed trait with exactly one subclass that has an Order instance
+""".trim)
 trait MkOrder[A] extends Order[A]
 
 object MkOrder extends MkOrderDerivation {

--- a/core/src/main/scala/cats/derived/partialOrder.scala
+++ b/core/src/main/scala/cats/derived/partialOrder.scala
@@ -22,7 +22,12 @@ import util.VersionSpecific.{OrElse, Lazy}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of PartialOrder[${A}]")
+@implicitNotFound("""
+Could not derive an instance of PartialOrder[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have a PartialOrder instance
+  * it is a sealed trait where all subclasses have a PartialOrder instance
+""".trim)
 trait MkPartialOrder[A] extends PartialOrder[A]
 
 object MkPartialOrder extends MkPartialOrderDerivation {

--- a/core/src/main/scala/cats/derived/pure.scala
+++ b/core/src/main/scala/cats/derived/pure.scala
@@ -22,7 +22,15 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Pure[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Pure[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T] where T: Empty
+  * it is a nested type λ[x => G[H[x]]] where G: Pure and H: Pure
+  * it is a generic case class where all fields have a Pure instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkPure[F[_]] extends Pure[F]
 
 object MkPure extends MkPureDerivation {

--- a/core/src/main/scala/cats/derived/semigroup.scala
+++ b/core/src/main/scala/cats/derived/semigroup.scala
@@ -22,7 +22,10 @@ import util.VersionSpecific.{OrElse, Lazy}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Semigroup[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Semigroup[A] where A = ${A}.
+Make sure that A is a case class where all fields have a Semigroup instance.
+""".trim)
 trait MkSemigroup[A] extends Semigroup[A]
 
 object MkSemigroup extends MkSemigroupDerivation {

--- a/core/src/main/scala/cats/derived/semigroupk.scala
+++ b/core/src/main/scala/cats/derived/semigroupk.scala
@@ -22,7 +22,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of SemigroupK[${F}]")
+@implicitNotFound("""
+Could not derive an instance of SemigroupK[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T] where T: Semigroup
+  * it is a nested type λ[x => G[H[x]]] where G: SemigroupK
+  * it is a nested type λ[x => G[H[x]]] where G: Apply and H: SemigroupK
+  * it is a generic case class where all fields have a SemigroupK instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkSemigroupK[F[_]] extends SemigroupK[F]
 
 object MkSemigroupK extends MkSemigroupKDerivation {

--- a/core/src/main/scala/cats/derived/show.scala
+++ b/core/src/main/scala/cats/derived/show.scala
@@ -19,7 +19,12 @@ import scala.annotation.implicitNotFound
  * See the test suite for more precise examples of what can and cannot
  * be derived.
  */
-@implicitNotFound("Could not derive an instance of Show[${A}]")
+@implicitNotFound("""
+Could not derive an instance of Show[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have a Show instance
+  * it is a sealed trait where all subclasses have a Show instance
+""".trim)
 trait MkShow[A] extends Show[A]
 
 object MkShow extends MkShowDerivation {

--- a/core/src/main/scala/cats/derived/showPretty.scala
+++ b/core/src/main/scala/cats/derived/showPretty.scala
@@ -16,7 +16,12 @@ object ShowPretty {
   def apply[A: ShowPretty]: ShowPretty[A] = implicitly
 }
 
-@implicitNotFound("Could not derive an instance of ShowPretty[${A}]")
+@implicitNotFound("""
+Could not derive an instance of ShowPretty[A] where A = ${A}.
+Make sure that A satisfies one of the following conditions:
+  * it is a case class where all fields have a Show instance
+  * it is a sealed trait where all subclasses have a Show instance
+""".trim)
 trait MkShowPretty[A] extends ShowPretty[A]
 
 object MkShowPretty extends MkShowPrettyDerivation {

--- a/core/src/main/scala/cats/derived/traverse.scala
+++ b/core/src/main/scala/cats/derived/traverse.scala
@@ -6,7 +6,16 @@ import util.VersionSpecific.OrElse
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Could not derive an instance of Traverse[${F}]")
+@implicitNotFound("""
+Could not derive an instance of Traverse[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a constant type λ[x => T]
+  * it is a nested type λ[x => G[H[x]]] where G: Traverse and H: Traverse
+  * it is a generic case class where all fields have a Traverse instance
+  * it is a generic sealed trait where all subclasses have a Traverse instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector
+""".trim)
 trait MkTraverse[F[_]] extends Traverse[F] {
   def safeTraverse[G[_]: Applicative, A, B](fa: F[A])(f: A => Eval[G[B]]): Eval[G[F[B]]]
   def safeFoldLeft[A, B](fa: F[A], b: B)(f: (B, A) => Eval[B]): Eval[B]


### PR DESCRIPTION
Putting this up for discussion. How exactly should we format and formulate the messages?

Current proposal:
  * One sentence to mention what exactly was not derived
  * One sentence to introduce a list of conditions
  * List the conditions, one of which must be satisfied

~Also: should we use kind-projector syntax or not?~

Closes #89 