### PR TITLE
Reducible derivation

### DIFF
--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -126,6 +126,12 @@ object auto {
     ): Foldable[F] = F.value
   }
 
+  object reducible {
+    implicit def kittensMkReducible[F[_]](
+      implicit refute: Refute[Reducible[F]], F: Lazy[MkReducible[F]]
+    ): Reducible[F] = F.value
+  }
+
   object traverse {
     implicit def kittensMkTraverse[F[_]](
       implicit refute: Refute[Traverse[F]], F: Lazy[MkTraverse[F]]
@@ -223,13 +229,19 @@ object cached {
     ): Foldable[F] = cached.value
   }
 
+  object reducible {
+    implicit def kittensMkReducible[F[_]](
+      implicit refute: Refute[Reducible[F]], cached: Cached[MkReducible[F]]
+    ): Reducible[F] = cached.value
+  }
+
   object invariant {
     implicit def kittensMkInvariant[F[_]](
       implicit refute: Refute[Invariant[F]], cached: Cached[MkInvariant[F]]
     ): Invariant[F] = cached.value
   }
 
-  object traverse{
+  object traverse {
     implicit def kittensMkTraverse[F[_]](
        implicit refute: Refute[Traverse[F]], cached: Cached[MkTraverse[F]]
     ): Traverse[F] = cached.value
@@ -336,6 +348,8 @@ object semi {
   def showPretty[A](implicit ev: Lazy[MkShowPretty[A]]): ShowPretty[A] = ev.value
 
   def foldable[F[_]](implicit F: Lazy[MkFoldable[F]]): Foldable[F] = F.value
+
+  def reducible[F[_]](implicit F: Lazy[MkReducible[F]]): Reducible[F] = F.value
 
   def traverse[F[_]](implicit F: Lazy[MkTraverse[F]]): Traverse[F] = F.value
 

--- a/core/src/main/scala/cats/derived/reducible.scala
+++ b/core/src/main/scala/cats/derived/reducible.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.derived
+
+import cats.{Eval, Foldable, Reducible}
+import shapeless._
+import util.VersionSpecific.OrElse
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("""Could not derive an instance of Reducible[F] where F = ${F}.
+Make sure that F[_] satisfies one of the following conditions:
+  * it is a nested type λ[x => G[H[x]]] where G: Reducible and H: Reducible
+  * it is a generic case class where at least one field has a Reducible and the rest Foldable instances
+  * it is a generic sealed trait where all subclasses have a Reducible instance
+
+Note: using kind-projector notation - https://github.com/typelevel/kind-projector""")
+trait MkReducible[F[_]] extends Reducible[F] with MkFoldable[F] {
+  def safeReduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => Eval[B]): Eval[B]
+
+  def reduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => B): B =
+    safeReduceLeftTo(fa)(f)((b, a) => Eval.later(g(b, a))).value
+}
+
+object MkReducible extends MkReducibleDerivation {
+  def apply[F[_]](implicit F: MkReducible[F]): MkReducible[F] = F
+}
+
+private[derived] abstract class MkReducibleDerivation extends MkReducibleBase {
+
+  implicit def mkReducibleNested[F[_]](implicit F: Split1[F, ReducibleOrMk, ReducibleOrMk]): MkReducible[F] =
+    new MkReducibleInstance(MkFoldable.mkFoldableNested(F.asInstanceOf[Split1[F, FoldableOrMk, FoldableOrMk]])) {
+
+      def safeReduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => Eval[B]) =
+        mkSafeReduceLeftTo(F.fo)(F.unpack(fa))(mkSafeReduceLeftTo(F.fi)(_)(f)(g)) {
+          (lb, fia) => lb.map(MkFoldable.mkSafeFoldLeft(F.fi)(fia, _)(g))
+        }.flatMap(identity)
+
+      def reduceRightTo[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]) = {
+        val fo = F.fo.unify
+        val fi = F.fi.unify
+        fo.reduceRightTo(F.unpack(fa))(fi.reduceRightTo(_)(f)(g)) {
+          (fia, llb) => Eval.later(fi.foldRight(fia, llb.value)(g))
+        }.flatMap(identity)
+      }
+    }
+}
+
+private[derived] abstract class MkReducibleBase extends MkReducibleCons {
+
+  implicit def mkReducibleHConsBase[F[_]](implicit F: IsHCons1[F, ReducibleOrMk, MkFoldable]): MkReducible[F] =
+    new MkReducibleInstance(MkFoldable.mkFoldableHCons(F.asInstanceOf[IsHCons1[F, FoldableOrMk, MkFoldable]])) {
+
+      def safeReduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => Eval[B]) =
+        Eval.now(F.unpack(fa)).flatMap { case (fha, fta) =>
+          mkSafeReduceLeftTo(F.fh)(fha)(f)(g).flatMap(F.ft.safeFoldLeft(fta, _)(g))
+        }
+
+      def reduceRightTo[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]) =
+        Eval.now(F.unpack(fa)).flatMap { case (fha, fta) =>
+          F.ft.reduceRightToOption(fta)(f)(g).flatMap {
+            case Some(b) => F.fh.unify.foldRight(fha, Eval.now(b))(g)
+            case None => F.fh.unify.reduceRightTo(fha)(f)(g)
+          }
+        }
+    }
+
+  implicit val mkReducibleCNil: MkReducible[Const[CNil]#λ] =
+    new MkReducible[Const[CNil]#λ] {
+      def safeFoldLeft[A, B](fa: CNil, b: B)(f: (B, A) => Eval[B]): Eval[B] = Eval.now(b)
+      def foldRight[A, B](fa: CNil, lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = lb
+      def safeReduceLeftTo[A, B](fa: CNil)(f: A => B)(g: (B, A) => Eval[B]) = unexpected
+      def reduceRightTo[A, B](fa: CNil)(f: A => B)(g: (A, Eval[B]) => Eval[B]) = unexpected
+    }
+}
+
+private[derived] abstract class MkReducibleCons extends MkReducibleGeneric {
+
+  implicit def mkReducibleHCons[F[_]](implicit F: IsHCons1[F, FoldableOrMk, MkReducible]): MkReducible[F] =
+    new MkReducibleInstance(MkFoldable.mkFoldableHCons(F.asInstanceOf[IsHCons1[F, FoldableOrMk, MkFoldable]])) {
+
+      def safeReduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => Eval[B]) =
+        Eval.now(F.unpack(fa)).flatMap { case (fha, fta) =>
+          MkFoldable.mkSafeFoldLeft(F.fh)(fha, Option.empty[B]) {
+            case (Some(b), a) => g(b, a).map(Some.apply)
+            case (None, a) => Eval.now(Some(f(a)))
+          }.flatMap {
+            case Some(b) => F.ft.safeFoldLeft(fta, b)(g)
+            case None => F.ft.safeReduceLeftTo(fta)(f)(g)
+          }
+        }
+
+      def reduceRightTo[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]) =
+        Eval.now(F.unpack(fa)).flatMap { case (fha, fta) =>
+          F.fh.unify.foldRight(fha, F.ft.reduceRightTo(fta)(f)(g))(g)
+        }
+    }
+
+  implicit def mkReducibleCCons[F[_]](implicit F: IsCCons1[F, ReducibleOrMk, MkReducible]): MkReducible[F] =
+    new MkReducibleInstance(MkFoldable.mkFoldableCCons(F.asInstanceOf[IsCCons1[F, FoldableOrMk, MkFoldable]])) {
+
+      def safeReduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => Eval[B]) =
+        F.unpack(fa) match {
+          case Left(fha) => mkSafeReduceLeftTo(F.fh)(fha)(f)(g)
+          case Right(fta) => F.ft.safeReduceLeftTo(fta)(f)(g)
+        }
+
+      def reduceRightTo[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]) =
+        F.unpack(fa) match {
+          case Left(fha) => F.fh.unify.reduceRightTo(fha)(f)(g)
+          case Right(fta) => F.ft.reduceRightTo(fta)(f)(g)
+        }
+    }
+}
+
+private[derived] abstract class MkReducibleGeneric {
+  protected type FoldableOrMk[F[_]] = Foldable[F] OrElse MkFoldable[F]
+  protected type ReducibleOrMk[F[_]] = Reducible[F] OrElse MkReducible[F]
+
+  protected abstract class MkReducibleInstance[F[_]](foldable: MkFoldable[F]) extends MkReducible[F] {
+
+    def safeFoldLeft[A, B](fa: F[A], b: B)(f: (B, A) => Eval[B]) =
+      foldable.safeFoldLeft(fa, b)(f)
+
+    def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]) =
+      foldable.foldRight(fa, lb)(f)
+  }
+
+  protected def mkSafeReduceLeftTo[F[_], A, B](
+    F: ReducibleOrMk[F]
+  )(fa: F[A])(f: A => B)(g: (B, A) => Eval[B]): Eval[B] = F.unify match {
+    case mk: MkReducible[F] => mk.safeReduceLeftTo(fa)(f)(g)
+    case other => Eval.later(other.reduceLeftTo(fa)(f)(g(_, _).value))
+  }
+
+  implicit def mkReducibleGeneric[F[_]](implicit F: Generic1[F, MkReducible]): MkReducible[F] =
+    new MkReducibleInstance(MkFoldable.mkFoldableGeneric(F.asInstanceOf[Generic1[F, MkFoldable]])) {
+
+      def safeReduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => Eval[B]) =
+        F.fr.safeReduceLeftTo(F.to(fa))(f)(g)
+
+      def reduceRightTo[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]) =
+        F.fr.reduceRightTo(F.to(fa))(f)(g)
+    }
+}

--- a/core/src/test/scala/cats/derived/adtdefns.scala
+++ b/core/src/test/scala/cats/derived/adtdefns.scala
@@ -103,6 +103,15 @@ object TestDefns {
   final case class ICons[A](head: A, tail: IList[A]) extends IList[A]
   final case class INil[A]() extends IList[A]
 
+  object ICons {
+
+    implicit def arbitrary[A: Arbitrary]: Arbitrary[ICons[A]] =
+      Arbitrary(for {
+        head <- Arbitrary.arbitrary[A]
+        tail <- Arbitrary.arbitrary[IList[A]]
+      } yield ICons(head, tail))
+  }
+
   object IList {
 
     implicit def arbitrary[A: Arbitrary]: Arbitrary[IList[A]] =
@@ -144,6 +153,15 @@ object TestDefns {
 
       loop(snoc, Nil)
     }
+  }
+
+  object SCons {
+
+    implicit def arbitrary[A: Arbitrary]: Arbitrary[SCons[A]] =
+      Arbitrary(for {
+        init <- Arbitrary.arbitrary[Snoc[A]]
+        last <- Arbitrary.arbitrary[A]
+      } yield SCons(init, last))
   }
 
   sealed trait Tree[A]
@@ -408,6 +426,9 @@ object TestEqInstances {
       case _ => false
     }
   }
+
+  implicit def eqICons[A: Eq]: Eq[ICons[A]] = Eq.by(identity[IList[A]])
+  implicit def eqSCons[A: Eq]: Eq[SCons[A]] = Eq.by(identity[Snoc[A]])
 
   implicit def eqTree[A](implicit A: Eq[A]): Eq[Tree[A]] = new Eq[Tree[A]] {
     def eqv(x: Tree[A], y: Tree[A]): Boolean = (x, y) match {

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -55,7 +55,7 @@ class FoldableSuite extends KittensSuite {
     val largeIList = IList.fromSeq(1 until n)
     val largeSnoc = Snoc.fromSeq(1 until n) :: Nil
 
-    test(s"$context.Traverse.foldLeft is stack safe") {
+    test(s"$context.Foldable.foldLeft is stack safe") {
       val actualIList = largeIList.foldLeft(0)(_ + _)
       val actualSnoc = listSnoc.foldLeft(largeSnoc, 0)(_ + _)
       val expected = n * (n - 1) / 2
@@ -63,7 +63,7 @@ class FoldableSuite extends KittensSuite {
       assert(actualSnoc == expected)
     }
 
-    test(s"$context.Traverse.foldRight is stack safe") {
+    test(s"$context.Foldable.foldRight is stack safe") {
       val actualIList = largeIList.foldRight(Eval.Zero)((i, sum) => sum.map(_ + i))
       val actualSnoc = listSnoc.foldRight(largeSnoc, Eval.Zero)((i, sum) => sum.map(_ + i))
       val expected = n * (n - 1) / 2
@@ -72,7 +72,7 @@ class FoldableSuite extends KittensSuite {
     }
 
     test(s"$context.Foldable respects existing instances") {
-      val tail = List.range(1, 100)
+      val tail = List.range(1, 10)
       val sum = boxNel.fold(Box(Nel(42, tail)))
       assert(sum == tail.sum)
     }

--- a/core/src/test/scala/cats/derived/reducible.scala
+++ b/core/src/test/scala/cats/derived/reducible.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package derived
+
+import cats.data.{NonEmptyList, OneAnd}
+import cats.instances.all._
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.{ReducibleTests, SerializableTests}
+import org.scalacheck.Arbitrary
+
+class ReducibleSuite extends KittensSuite {
+  import ReducibleSuite._
+  import TestDefns._
+  import TestEqInstances._
+
+  def testReducible(context: String)(
+    implicit iCons: Reducible[ICons],
+    tree: Reducible[Tree],
+    nelSCons: Reducible[NelSCons],
+    nelAndOne: Reducible[NelAndOne],
+    listAndNel: Reducible[ListAndNel],
+    interleaved: Reducible[Interleaved],
+    boxZipper: Reducible[BoxZipper]
+  ): Unit = {
+    checkAll(s"$context.Reducible[ICons]", ReducibleTests[ICons].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible[Tree]", ReducibleTests[Tree].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible[NelSCons]", ReducibleTests[NelSCons].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible[NelAndOne]", ReducibleTests[NelAndOne].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible[ListAndNel]", ReducibleTests[ListAndNel].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible[Interleaved]", ReducibleTests[Interleaved].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible[BoxZipper]", ReducibleTests[BoxZipper].reducible[Option, Int, Long])
+    checkAll(s"$context.Reducible is Serializable", SerializableTests.serializable(Reducible[Tree]))
+
+    val n = 10000
+    val largeIList = ICons(0, IList.fromSeq(1 until n))
+    val largeSnoc = NonEmptyList.one(SCons(Snoc.fromSeq(1 until n), 0))
+
+    test(s"$context.Reducible.reduceLeft is stack safe") {
+      val actualIList = largeIList.reduceLeft(_ + _)
+      val actualSnoc = nelSCons.reduceLeft(largeSnoc)(_ + _)
+      val expected = n * (n - 1) / 2
+      assert(actualIList == expected)
+      assert(actualSnoc == expected)
+    }
+
+    test(s"$context.Reducible.reduceRight is stack safe") {
+      val actualIList = largeIList.reduceRight((i, sum) => sum.map(_ + i))
+      val actualSnoc = nelSCons.reduceRight(largeSnoc)((i, sum) => sum.map(_ + i))
+      val expected = n * (n - 1) / 2
+      assert(actualIList.value == expected)
+      assert(actualSnoc.value == expected)
+    }
+
+    test(s"$context.Reducible respects existing instances") {
+      val list = List.range(1, 10)
+      val sum = boxZipper.reduce(Box(Zipper(list, 42, list)))
+      assert(sum == list.sum + 42)
+    }
+  }
+
+  {
+    import auto.reducible._
+    testReducible("auto")
+  }
+
+  {
+    import cached.reducible._
+    testReducible("cached")
+  }
+
+  {
+    import semiInstances._
+    testReducible("semi")
+  }
+}
+
+object ReducibleSuite {
+  import TestDefns._
+
+  type NelSCons[A] = NonEmptyList[SCons[A]]
+  type NelAndOne[A] = NonEmptyList[OneAnd[List, A]]
+  type ListAndNel[A] = (List[A], NonEmptyList[A])
+  type BoxZipper[A] = Box[Zipper[A]]
+
+  object semiInstances {
+    implicit val iCons: Reducible[ICons] = semi.reducible
+    implicit val tree: Reducible[Tree] = semi.reducible
+    implicit val nelSCons: Reducible[NelSCons] = semi.reducible
+    implicit val nelAndOne: Reducible[NelAndOne] = semi.reducible
+    implicit val listAndNel: Reducible[ListAndNel] = semi.reducible
+    implicit val interleaved: Reducible[Interleaved] = semi.reducible
+    implicit val boxZipper: Reducible[BoxZipper] = semi.reducible
+  }
+
+  final case class Zipper[+A](left: List[A], focus: A, right: List[A])
+  object Zipper {
+
+    implicit def eqv[A](implicit A: Eq[A]): Eq[Zipper[A]] = {
+      val listEq = Eq[List[A]]
+      Eq.instance { (x, y) =>
+        A.eqv(x.focus, y.focus) && listEq.eqv(x.left, y.left) && listEq.eqv(x.right, y.right)
+      }
+    }
+
+    implicit def arbitrary[A: Arbitrary]: Arbitrary[Zipper[A]] =
+      Arbitrary(for {
+        left <- Arbitrary.arbitrary[List[A]]
+        focus <- Arbitrary.arbitrary[A]
+        right <- Arbitrary.arbitrary[List[A]]
+      } yield Zipper(left, focus, right))
+
+    implicit val reducible: Reducible[Zipper] = new Reducible[Zipper] {
+
+      def reduceLeftTo[A, B](fa: Zipper[A])(f: A => B)(g: (B, A) => B) =
+        Reducible[NonEmptyList].reduceLeftTo(NonEmptyList(fa.focus, fa.right))(f)(g)
+
+      def reduceRightTo[A, B](fa: Zipper[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]) =
+        Reducible[NonEmptyList].reduceRightTo(NonEmptyList(fa.focus, fa.right))(f)(g)
+
+      def foldLeft[A, B](fa: Zipper[A], b: B)(f: (B, A) => B) =
+        Foldable[List].foldLeft(fa.focus :: fa.right, b)(f)
+
+      def foldRight[A, B](fa: Zipper[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]) =
+        Foldable[List].foldRight(fa.focus :: fa.right, lb)(f)
+    }
+  }
+}


### PR DESCRIPTION
Due to the interaction between `MkFoldable` and `MkReducible`,
`MkReducible` had to extend `MkFoldable` to be stack safe.
An alternative would be to add a `MkReducible` case in
`mkSafeFoldLeft`.

Part of #142