### PR TITLE
Deprecate auto in favor of semiauto

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cat: Cat[Int] = Cat(1,List(2, 3))
 ```scala
 scala> implicit val fc: Functor[Cat] = { 
           import auto.functor._           
-          semi.functor }
+          semiauto.functor }
 FC: cats.Functor[Cat] = cats.derived.MkFunctor2$$anon$4@1c60573f
 
 scala> cat.map(_ + 1)
@@ -82,7 +82,7 @@ scala> implicit val addressShow: Show[Address] = new Show[Address] {
 
 scala> implicit val peopleShow: Show[People] = {
             import auto.show._
-            semi.show
+            semiauto.show
         } //auto derive Show for People
 
 scala> mike.show
@@ -163,7 +163,7 @@ import cats.derived
 
 implicit val showFoo: Show[Foo] = {
    import derived.auto.show._
-   derived.semi.show
+   derived.semiauto.show
 }
 ```
 This will respect all existing instances even if the field is a type constructor. For example `Show[List[A]]` will use the native `Show` instance for `List` and derived instance for `A`. And it manually caches the result to the `val showFoo`. Downside user will need to write one for every type they directly need a `Show` instance
@@ -188,7 +188,7 @@ Use this one with caution. It caches the derived instance globally. So it's only
 
 3. manual semi
 ```scala
-implicit val showFoo: Show[Foo] =  derived.semi.show
+implicit val showFoo: Show[Foo] =  derived.semiauto.show
 ```
 It has the same downside as the recommenced semi-auto practice but also suffers from the type constructor field issue. I.e. if a field type is a type constructor whose native instance relies on the instance of the parameter type, this approach will by default derive an instance for the type constructor one. To overcome this user have to first derive the instance for type parameter. 
 e.g.  given
@@ -198,8 +198,8 @@ case class Bar(a: String)
 ```
 Since the `bars` field of `Foo` is a `List` of `Bar` which breaks the chains of auto derivation, you will need to derive `Bar` first and then `Foo`
 ```scala
-implicit val showBar: Show[Bar] =  semi.show
-implicit val showFoo: Show[Foo] =  semi.show
+implicit val showBar: Show[Bar] =  semiauto.show
+implicit val showFoo: Show[Foo] =  semiauto.show
 ```
 This way the native instance for `Show[List]` would be used.
 

--- a/core/src/main/scala-2.11/cats/derived/semiauto.scala
+++ b/core/src/main/scala-2.11/cats/derived/semiauto.scala
@@ -1,0 +1,34 @@
+package cats.derived
+
+/**
+ * allows semi automatically derive each instance. The derivation might need help when
+ * there are fields with type constructor that comes with instances
+ * e.g.
+ * {{{
+ * scala> case class Foo(bars: List[Bar])
+ * scala> case class Bar(a: String)
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res1: String = Foo(bars = $colon$colon(head = Bar(a = a), tl$access$1 = Nil.type()))
+ * }}}
+ * Note that semi.show didn't respect the native `Show[List]` instance
+ *
+ * You could either derive a Bar instance first
+ * {{{
+ * scala> implicit val barShow = cats.derived.semi.show[Bar]
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res2: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ *
+ * Or you can take advantage of a controlled auto derivation
+ * {{{
+ *   scala> implicit val fooShow: Show[Foo] = { |
+ *             import cats.derived.auto.show._  |
+ *             cats.derived.semiauto.show       |
+ *          }
+ *  scala> Foo(List(Bar("a"))).show
+ *  res3: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ */
+object semiauto extends SemiAutoInstances

--- a/core/src/main/scala-2.12/cats/derived/semiauto.scala
+++ b/core/src/main/scala-2.12/cats/derived/semiauto.scala
@@ -1,0 +1,34 @@
+package cats.derived
+
+/**
+ * allows semi automatically derive each instance. The derivation might need help when
+ * there are fields with type constructor that comes with instances
+ * e.g.
+ * {{{
+ * scala> case class Foo(bars: List[Bar])
+ * scala> case class Bar(a: String)
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res1: String = Foo(bars = $colon$colon(head = Bar(a = a), tl$access$1 = Nil.type()))
+ * }}}
+ * Note that semi.show didn't respect the native `Show[List]` instance
+ *
+ * You could either derive a Bar instance first
+ * {{{
+ * scala> implicit val barShow = cats.derived.semi.show[Bar]
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res2: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ *
+ * Or you can take advantage of a controlled auto derivation
+ * {{{
+ *   scala> implicit val fooShow: Show[Foo] = { |
+ *             import cats.derived.auto.show._  |
+ *             cats.derived.semiauto.show       |
+ *          }
+ *  scala> Foo(List(Bar("a"))).show
+ *  res3: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ */
+object semiauto extends SemiAutoInstances

--- a/core/src/main/scala-2.13/cats/derived/semiauto.scala
+++ b/core/src/main/scala-2.13/cats/derived/semiauto.scala
@@ -1,0 +1,73 @@
+package cats
+package derived
+
+import alleycats.{ConsK, Empty, EmptyK, Pure}
+import cats.kernel.{CommutativeMonoid, CommutativeSemigroup}
+
+/**
+ * allows semi automatically derive each instance. The derivation might need help when
+ * there are fields with type constructor that comes with instances
+ * e.g.
+ * {{{
+ * scala> case class Foo(bars: List[Bar])
+ * scala> case class Bar(a: String)
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res1: String = Foo(bars = $colon$colon(head = Bar(a = a), tl$access$1 = Nil.type()))
+ * }}}
+ * Note that semi.show didn't respect the native `Show[List]` instance
+ *
+ * You could either derive a Bar instance first
+ * {{{
+ * scala> implicit val barShow = cats.derived.semi.show[Bar]
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res2: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ *
+ * Or you can take advantage of a controlled auto derivation
+ * {{{
+ *   scala> implicit val fooShow: Show[Foo] = { |
+ *             import cats.derived.auto.show._  |
+ *             cats.derived.semiauto.show       |
+ *          }
+ *  scala> Foo(List(Bar("a"))).show
+ *  res3: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ */
+object semiauto {
+
+  def eq[A](implicit ev: MkEq[A]): Eq[A] = ev
+  def partialOrder[A](implicit ev: MkPartialOrder[A]): PartialOrder[A] = ev
+  def order[A](implicit ev: MkOrder[A]): Order[A] = ev
+  def hash[A](implicit ev: MkHash[A]): Hash[A] = ev
+
+  def show[A](implicit ev: MkShow[A]): Show[A] = ev
+  def showPretty[A](implicit ev: MkShowPretty[A]): ShowPretty[A] = ev
+
+  def empty[A](implicit ev: MkEmpty[A]): Empty[A] = ev
+  def emptyK[F[_]](implicit F: MkEmptyK[F]): EmptyK[F] = F
+
+  def semigroup[T](implicit ev: MkSemigroup[T]): Semigroup[T] = ev
+  def semigroupK[F[_]](implicit F: MkSemigroupK[F]): SemigroupK[F] = F
+  def commutativeSemigroup[T](implicit ev: MkCommutativeSemigroup[T]): CommutativeSemigroup[T] = ev
+
+  def monoid[A](implicit ev: MkMonoid[A]): Monoid[A] = ev
+  def monoidK[F[_]](implicit F: MkMonoidK[F]): MonoidK[F] = F
+  def commutativeMonoid[A](implicit ev: MkCommutativeMonoid[A]): CommutativeMonoid[A] = ev
+
+  def functor[F[_]](implicit F: MkFunctor[F]): Functor[F] = F
+  def contravariant[F[_]](implicit F: MkContravariant[F]): Contravariant[F] = F
+  def invariant[F[_]](implicit F: MkInvariant[F]): Invariant[F] = F
+  def pure[F[_]](implicit F: MkPure[F]): Pure[F] = F
+  def apply[F[_]](implicit F: MkApply[F]): Apply[F] = F
+  def applicative[F[_]](implicit F: MkApplicative[F]): Applicative[F] = F
+
+  def foldable[F[_]](implicit F: MkFoldable[F]): Foldable[F] = F
+  def reducible[F[_]](implicit F: MkReducible[F]): Reducible[F] = F
+  def traverse[F[_]](implicit F: MkTraverse[F]): Traverse[F] = F
+  def nonEmptyTraverse[F[_]](implicit F: MkNonEmptyTraverse[F]): NonEmptyTraverse[F] = F
+
+  def consK[F[_]](implicit F: MkConsK[F, F]): ConsK[F] = MkConsK.consK(F)
+  def iterable[F[_], A](fa: F[A])(implicit F: MkIterable[F]): Iterable[A] = F.iterable(fa)
+}

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -358,6 +358,7 @@ object cached {
   *  res3: String = Foo(bars = List(Bar(a = a)))
   * }}}
   */
+@deprecated(message = "Use semiauto instead.", since = "2.1.0")
 object semi {
 
   def empty[A](implicit ev: Lazy[MkEmpty[A]]): Empty[A] = ev.value
@@ -413,3 +414,66 @@ object semi {
   def invariant[F[_]](implicit F: Lazy[MkInvariant[F]]): Invariant[F] = F.value
 }
 
+/**
+ * allows semi automatically derive each instance. The derivation might need help when
+ * there are fields with type constructor that comes with instances
+ * e.g.
+ * {{{
+ * scala> case class Foo(bars: List[Bar])
+ * scala> case class Bar(a: String)
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res1: String = Foo(bars = $colon$colon(head = Bar(a = a), tl$access$1 = Nil.type()))
+ * }}}
+ * Note that semi.show didn't respect the native `Show[List]` instance
+ *
+ * You could either derive a Bar instance first
+ * {{{
+ * scala> implicit val barShow = cats.derived.semi.show[Bar]
+ *
+ * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
+ * res2: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ *
+ * Or you can take advantage of a controlled auto derivation
+ * {{{
+ *   scala> implicit val fooShow: Show[Foo] = { |
+ *             import cats.derived.auto.show._  |
+ *             cats.derived.semiauto.show       |
+ *          }
+ *  scala> Foo(List(Bar("a"))).show
+ *  res3: String = Foo(bars = List(Bar(a = a)))
+ * }}}
+ */
+object semiauto {
+
+  def eq[A](implicit ev: MkEq[A]): Eq[A] = ev
+  def partialOrder[A](implicit ev: MkPartialOrder[A]): PartialOrder[A] = ev
+  def order[A](implicit ev: MkOrder[A]): Order[A] = ev
+  def hash[A](implicit ev: MkHash[A]): Hash[A] = ev
+
+  def show[A](implicit ev: MkShow[A]): Show[A] = ev
+  def showPretty[A](implicit ev: MkShowPretty[A]): ShowPretty[A] = ev
+
+  def empty[A](implicit ev: MkEmpty[A]): Empty[A] = ev
+  def emptyK[F[_]](implicit F: MkEmptyK[F]): EmptyK[F] = F
+  def semigroup[T](implicit ev: MkSemigroup[T]): Semigroup[T] = ev
+  def semigroupK[F[_]](implicit F: MkSemigroupK[F]): SemigroupK[F] = F
+  def monoid[A](implicit ev: MkMonoid[A]): Monoid[A] = ev
+  def monoidK[F[_]](implicit F: MkMonoidK[F]): MonoidK[F] = F
+
+  def functor[F[_]](implicit F: MkFunctor[F]): Functor[F] = F
+  def contravariant[F[_]](implicit F: MkContravariant[F]): Contravariant[F] = F
+  def invariant[F[_]](implicit F: MkInvariant[F]): Invariant[F] = F
+  def pure[F[_]](implicit F: MkPure[F]): Pure[F] = F
+  def apply[F[_]](implicit F: MkApply[F]): Apply[F] = F
+  def applicative[F[_]](implicit F: MkApplicative[F]): Applicative[F] = F
+
+  def foldable[F[_]](implicit F: MkFoldable[F]): Foldable[F] = F
+  def reducible[F[_]](implicit F: MkReducible[F]): Reducible[F] = F
+  def traverse[F[_]](implicit F: MkTraverse[F]): Traverse[F] = F
+  def nonEmptyTraverse[F[_]](implicit F: MkNonEmptyTraverse[F]): NonEmptyTraverse[F] = F
+
+  def consK[F[_]](implicit F: MkConsK[F, F]): ConsK[F] = MkConsK.consK(F)
+  def iterable[F[_], A](fa: F[A])(implicit F: MkIterable[F]): Iterable[A] = F.iterable(fa)
+}

--- a/core/src/main/scala/cats/derived/package.scala
+++ b/core/src/main/scala/cats/derived/package.scala
@@ -1,10 +1,10 @@
 package cats
 package derived
 
-import cats.kernel.{CommutativeMonoid, CommutativeSemigroup}
 import alleycats._
+import cats.derived.util.VersionSpecific.Lazy
+import cats.kernel.{CommutativeMonoid, CommutativeSemigroup}
 import shapeless.{Cached, Refute}
-import util.VersionSpecific.Lazy
 
 /**
   * Fully automatically derive the instance, note that this derivation is not cached, so it
@@ -327,6 +327,43 @@ object cached {
   }
 }
 
+private[derived] abstract class SemiAutoInstances {
+
+  def eq[A](implicit ev: Lazy[MkEq[A]]): Eq[A] = ev.value
+  def partialOrder[A](implicit ev: Lazy[MkPartialOrder[A]]): PartialOrder[A] = ev.value
+  def order[A](implicit ev: Lazy[MkOrder[A]]): Order[A] = ev.value
+  def hash[A](implicit ev: Lazy[MkHash[A]]): Hash[A] = ev.value
+
+  def show[A](implicit ev: Lazy[MkShow[A]]): Show[A] = ev.value
+  def showPretty[A](implicit ev: Lazy[MkShowPretty[A]]): ShowPretty[A] = ev.value
+
+  def empty[A](implicit ev: Lazy[MkEmpty[A]]): Empty[A] = ev.value
+  def emptyK[F[_]](implicit F: Lazy[MkEmptyK[F]]): EmptyK[F] = F.value
+
+  def semigroup[T](implicit ev: Lazy[MkSemigroup[T]]): Semigroup[T] = ev.value
+  def semigroupK[F[_]](implicit F: Lazy[MkSemigroupK[F]]): SemigroupK[F] = F.value
+  def commutativeSemigroup[T](implicit ev: Lazy[MkCommutativeSemigroup[T]]): CommutativeSemigroup[T] = ev.value
+
+  def monoid[A](implicit ev: Lazy[MkMonoid[A]]): Monoid[A] = ev.value
+  def monoidK[F[_]](implicit F: Lazy[MkMonoidK[F]]): MonoidK[F] = F.value
+  def commutativeMonoid[A](implicit ev: Lazy[MkCommutativeMonoid[A]]): CommutativeMonoid[A] = ev.value
+
+  def functor[F[_]](implicit F: Lazy[MkFunctor[F]]): Functor[F] = F.value
+  def contravariant[F[_]](implicit F: Lazy[MkContravariant[F]]): Contravariant[F] = F.value
+  def invariant[F[_]](implicit F: Lazy[MkInvariant[F]]): Invariant[F] = F.value
+  def pure[F[_]](implicit F: Lazy[MkPure[F]]): Pure[F] = F.value
+  def apply[F[_]](implicit F: Lazy[MkApply[F]]): Apply[F] = F.value
+  def applicative[F[_]](implicit F: Lazy[MkApplicative[F]]): Applicative[F] = F.value
+
+  def foldable[F[_]](implicit F: Lazy[MkFoldable[F]]): Foldable[F] = F.value
+  def reducible[F[_]](implicit F: Lazy[MkReducible[F]]): Reducible[F] = F.value
+  def traverse[F[_]](implicit F: Lazy[MkTraverse[F]]): Traverse[F] = F.value
+  def nonEmptyTraverse[F[_]](implicit F: Lazy[MkNonEmptyTraverse[F]]): NonEmptyTraverse[F] = F.value
+
+  def consK[F[_]](implicit F: Lazy[MkConsK[F, F]]): ConsK[F] = MkConsK.consK(F.value)
+  def iterable[F[_], A](fa: F[A])(implicit F: MkIterable[F]): Iterable[A] = F.iterable(fa)
+}
+
 /**
   * allows semi automatically derive each instance. The derivation might need help when
   * there are fields with type constructor that comes with instances
@@ -359,121 +396,4 @@ object cached {
   * }}}
   */
 @deprecated(message = "Use semiauto instead.", since = "2.1.0")
-object semi {
-
-  def empty[A](implicit ev: Lazy[MkEmpty[A]]): Empty[A] = ev.value
-
-  def emptyK[F[_]](implicit F: Lazy[MkEmptyK[F]]): EmptyK[F] = F.value
-
-  def eq[A](implicit ev: Lazy[MkEq[A]]): Eq[A] = ev.value
-
-  def partialOrder[A](implicit ev: Lazy[MkPartialOrder[A]]): PartialOrder[A] = ev.value
-
-  def order[A](implicit ev: Lazy[MkOrder[A]]): Order[A] = ev.value
-
-  def hash[A](implicit ev: Lazy[MkHash[A]]): Hash[A] = ev.value
-
-  def contravariant[F[_]](implicit F: Lazy[MkContravariant[F]]): Contravariant[F] = F.value
-
-  def functor[F[_]](implicit F: Lazy[MkFunctor[F]]): Functor[F] = F.value
-
-  def apply[F[_]](implicit F: Lazy[MkApply[F]]): Apply[F] = F.value
-
-  def applicative[F[_]](implicit F: Lazy[MkApplicative[F]]): Applicative[F] = F.value
-
-  def show[A](implicit ev: Lazy[MkShow[A]]): Show[A] = ev.value
-
-  def showPretty[A](implicit ev: Lazy[MkShowPretty[A]]): ShowPretty[A] = ev.value
-
-  def foldable[F[_]](implicit F: Lazy[MkFoldable[F]]): Foldable[F] = F.value
-
-  def reducible[F[_]](implicit F: Lazy[MkReducible[F]]): Reducible[F] = F.value
-
-  def traverse[F[_]](implicit F: Lazy[MkTraverse[F]]): Traverse[F] = F.value
-
-  def nonEmptyTraverse[F[_]](implicit F: Lazy[MkNonEmptyTraverse[F]]): NonEmptyTraverse[F] = F.value
-
-  def monoid[A](implicit ev: Lazy[MkMonoid[A]]): Monoid[A] = ev.value
-
-  def commutativeMonoid[A](implicit ev: Lazy[MkCommutativeMonoid[A]]): CommutativeMonoid[A] = ev.value
-
-  def monoidK[F[_]](implicit F: Lazy[MkMonoidK[F]]): MonoidK[F] = F.value
-
-  def pure[F[_]](implicit F: Lazy[MkPure[F]]): Pure[F] = F.value
-
-  def semigroup[T](implicit ev: Lazy[MkSemigroup[T]]): Semigroup[T] = ev.value
-
-  def commutativeSemigroup[T](implicit ev: Lazy[MkCommutativeSemigroup[T]]): CommutativeSemigroup[T] = ev.value
-
-  def semigroupK[F[_]](implicit F: Lazy[MkSemigroupK[F]]): SemigroupK[F] = F.value
-
-  def consK[F[_]](implicit F: Lazy[MkConsK[F, F]]): ConsK[F] = MkConsK.consK(F.value)
-
-  def iterable[F[_], A](fa: F[A])(implicit F: MkIterable[F]): Iterable[A] = F.iterable(fa)
-
-  def invariant[F[_]](implicit F: Lazy[MkInvariant[F]]): Invariant[F] = F.value
-}
-
-/**
- * allows semi automatically derive each instance. The derivation might need help when
- * there are fields with type constructor that comes with instances
- * e.g.
- * {{{
- * scala> case class Foo(bars: List[Bar])
- * scala> case class Bar(a: String)
- *
- * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
- * res1: String = Foo(bars = $colon$colon(head = Bar(a = a), tl$access$1 = Nil.type()))
- * }}}
- * Note that semi.show didn't respect the native `Show[List]` instance
- *
- * You could either derive a Bar instance first
- * {{{
- * scala> implicit val barShow = cats.derived.semi.show[Bar]
- *
- * scala> cats.derived.semiauto.show[Foo].show(Foo(List(Bar("a"))))
- * res2: String = Foo(bars = List(Bar(a = a)))
- * }}}
- *
- * Or you can take advantage of a controlled auto derivation
- * {{{
- *   scala> implicit val fooShow: Show[Foo] = { |
- *             import cats.derived.auto.show._  |
- *             cats.derived.semiauto.show       |
- *          }
- *  scala> Foo(List(Bar("a"))).show
- *  res3: String = Foo(bars = List(Bar(a = a)))
- * }}}
- */
-object semiauto {
-
-  def eq[A](implicit ev: MkEq[A]): Eq[A] = ev
-  def partialOrder[A](implicit ev: MkPartialOrder[A]): PartialOrder[A] = ev
-  def order[A](implicit ev: MkOrder[A]): Order[A] = ev
-  def hash[A](implicit ev: MkHash[A]): Hash[A] = ev
-
-  def show[A](implicit ev: MkShow[A]): Show[A] = ev
-  def showPretty[A](implicit ev: MkShowPretty[A]): ShowPretty[A] = ev
-
-  def empty[A](implicit ev: MkEmpty[A]): Empty[A] = ev
-  def emptyK[F[_]](implicit F: MkEmptyK[F]): EmptyK[F] = F
-  def semigroup[T](implicit ev: MkSemigroup[T]): Semigroup[T] = ev
-  def semigroupK[F[_]](implicit F: MkSemigroupK[F]): SemigroupK[F] = F
-  def monoid[A](implicit ev: MkMonoid[A]): Monoid[A] = ev
-  def monoidK[F[_]](implicit F: MkMonoidK[F]): MonoidK[F] = F
-
-  def functor[F[_]](implicit F: MkFunctor[F]): Functor[F] = F
-  def contravariant[F[_]](implicit F: MkContravariant[F]): Contravariant[F] = F
-  def invariant[F[_]](implicit F: MkInvariant[F]): Invariant[F] = F
-  def pure[F[_]](implicit F: MkPure[F]): Pure[F] = F
-  def apply[F[_]](implicit F: MkApply[F]): Apply[F] = F
-  def applicative[F[_]](implicit F: MkApplicative[F]): Applicative[F] = F
-
-  def foldable[F[_]](implicit F: MkFoldable[F]): Foldable[F] = F
-  def reducible[F[_]](implicit F: MkReducible[F]): Reducible[F] = F
-  def traverse[F[_]](implicit F: MkTraverse[F]): Traverse[F] = F
-  def nonEmptyTraverse[F[_]](implicit F: MkNonEmptyTraverse[F]): NonEmptyTraverse[F] = F
-
-  def consK[F[_]](implicit F: MkConsK[F, F]): ConsK[F] = MkConsK.consK(F)
-  def iterable[F[_], A](fa: F[A])(implicit F: MkIterable[F]): Iterable[A] = F.iterable(fa)
-}
+object semi extends SemiAutoInstances

--- a/core/src/test/scala/cats/derived/applicative.scala
+++ b/core/src/test/scala/cats/derived/applicative.scala
@@ -22,12 +22,9 @@ import cats.laws.discipline.{ApplicativeTests, SerializableTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 class ApplicativeSuite extends KittensSuite {
+  import ApplicativeSuite._
   import TestDefns._
   import TestEqInstances._
-
-  type OptList[A] = Option[List[A]]
-  type AndInt[A] = (A, Int)
-  type ListBox[A] = List[Box[A]]
 
   def testApplicative(context: String)(
     implicit caseClassWOption: Applicative[CaseClassWOption],
@@ -58,12 +55,23 @@ class ApplicativeSuite extends KittensSuite {
   }
 
   {
-    implicit val caseClassWOption: Applicative[CaseClassWOption] = semi.applicative
-    implicit val optList: Applicative[OptList] = semi.applicative
-    implicit val andInt: Applicative[AndInt] = semi.applicative
-    implicit val interleaved: Applicative[Interleaved] = semi.applicative
-    implicit val listBox: Applicative[ListBox] = semi.applicative
-    testApplicative("semi")
+    import semiInstances._
+    testApplicative("semiauto")
   }
 }
 
+object ApplicativeSuite {
+  import TestDefns._
+
+  type OptList[A] = Option[List[A]]
+  type AndInt[A] = (A, Int)
+  type ListBox[A] = List[Box[A]]
+
+  object semiInstances {
+    implicit val caseClassWOption: Applicative[CaseClassWOption] = semiauto.applicative
+    implicit val optList: Applicative[OptList] = semiauto.applicative
+    implicit val andInt: Applicative[AndInt] = semiauto.applicative
+    implicit val interleaved: Applicative[Interleaved] = semiauto.applicative
+    implicit val listBox: Applicative[ListBox] = semiauto.applicative
+  }
+}

--- a/core/src/test/scala/cats/derived/apply.scala
+++ b/core/src/test/scala/cats/derived/apply.scala
@@ -22,12 +22,9 @@ import cats.laws.discipline.{ApplyTests, SerializableTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 class ApplySuite extends KittensSuite {
+  import ApplySuite._
   import TestDefns._
   import TestEqInstances._
-
-  type OptList[A] = Option[List[A]]
-  type AndInt[A] = (A, Int)
-  type ListBox[A] = List[Box[A]]
 
   def testApply(context: String)(
     implicit caseClassWOption: Apply[CaseClassWOption],
@@ -58,12 +55,23 @@ class ApplySuite extends KittensSuite {
   }
 
   {
-    implicit val caseClassWOption: Apply[CaseClassWOption] = semi.apply
-    implicit val optList: Apply[OptList] = semi.apply
-    implicit val andInt: Apply[AndInt] = semi.apply
-    implicit val interleaved: Apply[Interleaved] = semi.apply
-    implicit val listBox: Apply[ListBox] = semi.apply
-    testApply("semi")
+    import semiInstances._
+    testApply("semiauto")
   }
 }
 
+object ApplySuite {
+  import TestDefns._
+
+  type OptList[A] = Option[List[A]]
+  type AndInt[A] = (A, Int)
+  type ListBox[A] = List[Box[A]]
+
+  object semiInstances {
+    implicit val caseClassWOption: Apply[CaseClassWOption] = semiauto.apply
+    implicit val optList: Apply[OptList] = semiauto.apply
+    implicit val andInt: Apply[AndInt] = semiauto.apply
+    implicit val interleaved: Apply[Interleaved] = semiauto.apply
+    implicit val listBox: Apply[ListBox] = semiauto.apply
+  }
+}

--- a/core/src/test/scala/cats/derived/commutativeMonoid.scala
+++ b/core/src/test/scala/cats/derived/commutativeMonoid.scala
@@ -54,9 +54,9 @@ class CommutativeMonoidSuite extends KittensSuite {
   }
 
   {
-    implicit val foo: CommutativeMonoid[CommutativeFoo] = semi.commutativeMonoid
-    implicit lazy val recursive: CommutativeMonoid[Recursive] = semi.commutativeMonoid
-    implicit val box: CommutativeMonoid[Box[Mul]] = semi.commutativeMonoid
+    implicit val foo: CommutativeMonoid[CommutativeFoo] = semiauto.commutativeMonoid
+    implicit lazy val recursive: CommutativeMonoid[Recursive] = semiauto.commutativeMonoid
+    implicit val box: CommutativeMonoid[Box[Mul]] = semiauto.commutativeMonoid
     testCommutativeMonoid("semi")
   }
 }

--- a/core/src/test/scala/cats/derived/commutativeSemigroup.scala
+++ b/core/src/test/scala/cats/derived/commutativeSemigroup.scala
@@ -53,9 +53,9 @@ class CommutativeSemigroupSuite extends KittensSuite {
   }
 
   {
-    implicit val foo: CommutativeSemigroup[CommutativeFoo] = semi.commutativeSemigroup
-    implicit lazy val recursive: CommutativeSemigroup[Recursive] = semi.commutativeSemigroup
-    implicit val box: CommutativeSemigroup[Box[Mul]] = semi.commutativeSemigroup
+    implicit val foo: CommutativeSemigroup[CommutativeFoo] = semiauto.commutativeSemigroup
+    implicit lazy val recursive: CommutativeSemigroup[Recursive] = semiauto.commutativeSemigroup
+    implicit val box: CommutativeSemigroup[Box[Mul]] = semiauto.commutativeSemigroup
     testCommutativeSemigroup("semi")
   }
 }

--- a/core/src/test/scala/cats/derived/consk.scala
+++ b/core/src/test/scala/cats/derived/consk.scala
@@ -22,6 +22,7 @@ import org.scalacheck.Arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class ConsKSuite extends KittensSuite with ScalaCheckDrivenPropertyChecks {
+  import ConsKSuite._
   import TestDefns._
 
   def checkConsK[F[_], A : Arbitrary](nil: F[A])(fromSeq: Seq[A] => F[A])(implicit F: ConsK[F]): Unit =
@@ -44,8 +45,16 @@ class ConsKSuite extends KittensSuite with ScalaCheckDrivenPropertyChecks {
   }
 
   {
-    implicit val iList: ConsK[IList] = semi.consK[IList]
-    implicit val snoc: ConsK[Snoc] = semi.consK[Snoc]
+    import semiInstances._
     testConsK("semi")
+  }
+}
+
+object ConsKSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val iList: ConsK[IList] = semiauto.consK[IList]
+    implicit val snoc: ConsK[Snoc] = semiauto.consK[Snoc]
   }
 }

--- a/core/src/test/scala/cats/derived/contravariant.scala
+++ b/core/src/test/scala/cats/derived/contravariant.scala
@@ -23,16 +23,9 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 
 class ContravariantSuite extends KittensSuite {
+  import ContravariantSuite._
   import TestDefns._
   import TestEqInstances._
-
-  type OptPred[A] = Option[A => Boolean]
-  type ListPred[A] = List[A => Boolean]
-  type GenericAdtPred[A] = GenericAdt[A => Boolean]
-  type ListSnocF[A] = List[Snoc[A => Int]]
-  type InterleavedPred[A] = Interleaved[A => Boolean]
-  type AndCharPred[A] = (A => Boolean, Char)
-  type TreePred[A] = Tree[A => Boolean]
 
   def testContravariant(context: String)(
     implicit
@@ -71,17 +64,31 @@ class ContravariantSuite extends KittensSuite {
     testContravariant("cached")
   }
 
-  semiTests.run()
+  {
+    import semiInstances._
+    testContravariant("semiauto")
+  }
+}
 
-  object semiTests {
-    implicit val optPred: Contravariant[OptPred] = semi.contravariant
-    implicit val listPred: Contravariant[ListPred] = semi.contravariant
-    implicit val genericAdtPred: Contravariant[GenericAdtPred] = semi.contravariant
-    implicit val listSnocF: Contravariant[ListSnocF] = semi.contravariant
-    implicit val interleavePred: Contravariant[InterleavedPred] = semi.contravariant
-    implicit val andCharPred: Contravariant[AndCharPred] = semi.contravariant
-    implicit val treePred: Contravariant[TreePred] = semi.contravariant
-    def run(): Unit = testContravariant("semi")
+object ContravariantSuite {
+  import TestDefns._
+
+  type OptPred[A] = Option[A => Boolean]
+  type ListPred[A] = List[A => Boolean]
+  type GenericAdtPred[A] = GenericAdt[A => Boolean]
+  type ListSnocF[A] = List[Snoc[A => Int]]
+  type InterleavedPred[A] = Interleaved[A => Boolean]
+  type AndCharPred[A] = (A => Boolean, Char)
+  type TreePred[A] = Tree[A => Boolean]
+
+  object semiInstances {
+    implicit val optPred: Contravariant[OptPred] = semiauto.contravariant
+    implicit val listPred: Contravariant[ListPred] = semiauto.contravariant
+    implicit val genericAdtPred: Contravariant[GenericAdtPred] = semiauto.contravariant
+    implicit val listSnocF: Contravariant[ListSnocF] = semiauto.contravariant
+    implicit val interleavePred: Contravariant[InterleavedPred] = semiauto.contravariant
+    implicit val andCharPred: Contravariant[AndCharPred] = semiauto.contravariant
+    implicit val treePred: Contravariant[TreePred] = semiauto.contravariant
   }
 }
 

--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -26,9 +26,6 @@ class EmptySuite extends KittensSuite {
   import EmptySuite._
   import TestDefns._
 
-  // `Monoid[Option[A]]` gives us `Empty[Option[A]]` but it requires a `Semigroup[A]`.
-  implicit def emptyOption[A]: Empty[Option[A]] = Empty(None)
-
   def testEmpty(context: String)(
     implicit foo: Empty[Foo],
     outer: Empty[Outer],
@@ -73,26 +70,30 @@ class EmptySuite extends KittensSuite {
   }
 
   {
-    semiTests.run()
+    import semiInstances._
     illTyped("semi.empty[IList[Int]]")
     illTyped("semi.empty[Snoc[Int]]")
     illTyped("semi.empty[Rgb]")
-  }
-
-  object semiTests {
-    implicit val foo: Empty[Foo] = semi.empty
-    implicit val outer: Empty[Outer] = semi.empty
-    implicit val interleaved: Empty[Interleaved[String]] = semi.empty
-    implicit val recursive: Empty[Recursive] = semi.empty
-    implicit val iList: Empty[IList[Dummy]] = semi.empty
-    implicit val snoc: Empty[Snoc[Dummy]] = semi.empty
-    implicit val box: Empty[Box[Mask]] = semi.empty
-    implicit val chain: Empty[Chain] = semi.empty
-    def run(): Unit = testEmpty("semi")
+    testEmpty("semiauto")
   }
 }
 
 object EmptySuite {
+  import TestDefns._
+
+  // `Monoid[Option[A]]` gives us `Empty[Option[A]]` but it requires a `Semigroup[A]`.
+  implicit def emptyOption[A]: Empty[Option[A]] = Empty(None)
+
+  object semiInstances {
+    implicit val foo: Empty[Foo] = semiauto.empty
+    implicit val outer: Empty[Outer] = semiauto.empty
+    implicit val interleaved: Empty[Interleaved[String]] = semiauto.empty
+    implicit val recursive: Empty[Recursive] = semiauto.empty
+    implicit val iList: Empty[IList[Dummy]] = semiauto.empty
+    implicit val snoc: Empty[Snoc[Dummy]] = semiauto.empty
+    implicit val box: Empty[Box[Mask]] = semiauto.empty
+    implicit val chain: Empty[Chain] = semiauto.empty
+  }
 
   trait Dummy
   final case class Chain(head: Int, tail: Chain)

--- a/core/src/test/scala/cats/derived/emptyk.scala
+++ b/core/src/test/scala/cats/derived/emptyk.scala
@@ -27,11 +27,6 @@ class EmptyKSuite extends KittensSuite {
   import EmptyKSuite._
   import TestDefns._
 
-  type LOption[A] = List[Option[A]]
-  type PList[A] = (List[A], List[A])
-  type NelOption[A] = NonEmptyList[Option[A]]
-  type BoxColor[A] = Box[Color[A]]
-
   def testEmptyK(context: String)(
     implicit lOption: EmptyK[LOption],
     pList: EmptyK[PList],
@@ -66,18 +61,28 @@ class EmptyKSuite extends KittensSuite {
   }
 
   {
-    implicit val lOption: EmptyK[LOption] = semi.emptyK
-    implicit val pList: EmptyK[PList] = semi.emptyK
-    implicit val caseClassWOption: EmptyK[CaseClassWOption] = semi.emptyK
-    implicit val nelOption: EmptyK[NelOption] = semi.emptyK
-    implicit val boxColor: EmptyK[BoxColor] = semi.emptyK
-    testEmptyK("semi")
-    illTyped("semi.emptyK[IList]")
-    illTyped("semi.emptyK[Snoc]")
+    import semiInstances._
+    testEmptyK("semiauto")
+    illTyped("semiauto.emptyK[IList]")
+    illTyped("semiauto.emptyK[Snoc]")
   }
 }
 
 object EmptyKSuite {
+  import TestDefns._
+
+  type LOption[A] = List[Option[A]]
+  type PList[A] = (List[A], List[A])
+  type NelOption[A] = NonEmptyList[Option[A]]
+  type BoxColor[A] = Box[Color[A]]
+
+  object semiInstances {
+    implicit val lOption: EmptyK[LOption] = semiauto.emptyK
+    implicit val pList: EmptyK[PList] = semiauto.emptyK
+    implicit val caseClassWOption: EmptyK[CaseClassWOption] = semiauto.emptyK
+    implicit val nelOption: EmptyK[NelOption] = semiauto.emptyK
+    implicit val boxColor: EmptyK[BoxColor] = semiauto.emptyK
+  }
 
   final case class Color[A](r: Int, g: Int, b: Int)
   object Color {

--- a/core/src/test/scala/cats/derived/eq.scala
+++ b/core/src/test/scala/cats/derived/eq.scala
@@ -21,6 +21,7 @@ import cats.kernel.laws.discipline.{EqTests, SerializableTests}
 import cats.instances.all._
 
 class EqSuite extends KittensSuite {
+  import EqSuite._
   import TestDefns._
 
   def testEq(context: String)(
@@ -52,16 +53,22 @@ class EqSuite extends KittensSuite {
     testEq("cached")
   }
 
-  semiTests.run()
+  {
+    import semiInstances._
+    testEq("semiauto")
+  }
+}
 
-  object semiTests {
-    implicit val foo: Eq[Foo] = semi.eq
-    implicit val iList: Eq[IList[Int]] = semi.eq
-    implicit val inner: Eq[Inner] = semi.eq
-    implicit val outer: Eq[Outer] = semi.eq
-    implicit val interleaved: Eq[Interleaved[Int]] = semi.eq
-    implicit val tree: Eq[Tree[Int]] = semi.eq
-    implicit val recursive: Eq[Recursive] = semi.eq
-    def run(): Unit = testEq("semi")
+object EqSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val foo: Eq[Foo] = semiauto.eq
+    implicit val iList: Eq[IList[Int]] = semiauto.eq
+    implicit val inner: Eq[Inner] = semiauto.eq
+    implicit val outer: Eq[Outer] = semiauto.eq
+    implicit val interleaved: Eq[Interleaved[Int]] = semiauto.eq
+    implicit val tree: Eq[Tree[Int]] = semiauto.eq
+    implicit val recursive: Eq[Recursive] = semiauto.eq
   }
 }

--- a/core/src/test/scala/cats/derived/foldable.scala
+++ b/core/src/test/scala/cats/derived/foldable.scala
@@ -26,11 +26,6 @@ class FoldableSuite extends KittensSuite {
   import TestDefns._
   import TestEqInstances._
 
-  type OptList[A] = Option[List[A]]
-  type ListSnoc[A] = List[Snoc[A]]
-  type AndChar[A] = (A, Char)
-  type BoxNel[A] = Box[Nel[A]]
-
   def testFoldable(context: String)(
     implicit iList: Foldable[IList],
     tree: Foldable[Tree],
@@ -88,22 +83,30 @@ class FoldableSuite extends KittensSuite {
     testFoldable("cached")
   }
 
-  semiTests.run()
-
-  object semiTests {
-    implicit val iList: Foldable[IList] = semi.foldable
-    implicit val tree: Foldable[Tree] = semi.foldable
-    implicit val genericAdt: Foldable[GenericAdt] = semi.foldable
-    implicit val optList: Foldable[OptList] = semi.foldable
-    implicit val listSnoc: Foldable[ListSnoc] = semi.foldable
-    implicit val andChar: Foldable[AndChar] = semi.foldable
-    implicit val interleaved: Foldable[Interleaved] = semi.foldable
-    implicit val boxNel: Foldable[BoxNel] = semi.foldable
-    def run(): Unit = testFoldable("semi")
+  {
+    import semiInstances._
+    testFoldable("semiauto")
   }
 }
 
 object FoldableSuite {
+  import TestDefns._
+
+  type OptList[A] = Option[List[A]]
+  type ListSnoc[A] = List[Snoc[A]]
+  type AndChar[A] = (A, Char)
+  type BoxNel[A] = Box[Nel[A]]
+
+  object semiInstances {
+    implicit val iList: Foldable[IList] = semiauto.foldable
+    implicit val tree: Foldable[Tree] = semiauto.foldable
+    implicit val genericAdt: Foldable[GenericAdt] = semiauto.foldable
+    implicit val optList: Foldable[OptList] = semiauto.foldable
+    implicit val listSnoc: Foldable[ListSnoc] = semiauto.foldable
+    implicit val andChar: Foldable[AndChar] = semiauto.foldable
+    implicit val interleaved: Foldable[Interleaved] = semiauto.foldable
+    implicit val boxNel: Foldable[BoxNel] = semiauto.foldable
+  }
 
   final case class Nel[+A](head: A, tail: List[A])
   object Nel {

--- a/core/src/test/scala/cats/derived/functor.scala
+++ b/core/src/test/scala/cats/derived/functor.scala
@@ -22,16 +22,11 @@ import cats.laws.discipline._
 import cats.laws.discipline.eq._
 
 class FunctorSuite extends KittensSuite {
+  import FunctorSuite._
   import TestDefns._
   import TestEqInstances._
 
-  type OptList[A] = Option[List[A]]
-  type ListSnoc[A] = List[Snoc[A]]
-  type AndChar[A] = (A, Char)
-  type Pred[A] = A => Boolean
-  type NestedPred[A] = Pred[Pred[A]]
-
-  implicit val exhaustivePred: ExhaustiveCheck[Pred[Boolean]] =
+  implicit val exhaustivePred: ExhaustiveCheck[Predicate[Boolean]] =
     ExhaustiveCheck.instance(List(_ => true, _ => false, identity, !_))
 
   def testFunctor(context: String)(
@@ -76,18 +71,29 @@ class FunctorSuite extends KittensSuite {
     testFunctor("cached")
   }
 
-  semiTests.run()
-
-  object semiTests {
-    implicit val iList: Functor[IList] = semi.functor
-    implicit val tree: Functor[Tree] = semi.functor
-    implicit val genericAdt: Functor[GenericAdt] = semi.functor
-    implicit val optList: Functor[OptList] = semi.functor
-    implicit val listSnoc: Functor[ListSnoc] = semi.functor
-    implicit val andChar: Functor[AndChar] = semi.functor
-    implicit val interleaved: Functor[Interleaved] = semi.functor
-    implicit val nestedPred: Functor[NestedPred] = semi.functor
-    def run(): Unit = testFunctor("semi")
+  {
+    import semiInstances._
+    testFunctor("semiauto")
   }
 }
 
+object FunctorSuite {
+  import TestDefns._
+
+  type OptList[A] = Option[List[A]]
+  type ListSnoc[A] = List[Snoc[A]]
+  type AndChar[A] = (A, Char)
+  type Predicate[A] = A => Boolean
+  type NestedPred[A] = Predicate[Predicate[A]]
+
+  object semiInstances {
+    implicit val iList: Functor[IList] = semiauto.functor
+    implicit val tree: Functor[Tree] = semiauto.functor
+    implicit val genericAdt: Functor[GenericAdt] = semiauto.functor
+    implicit val optList: Functor[OptList] = semiauto.functor
+    implicit val listSnoc: Functor[ListSnoc] = semiauto.functor
+    implicit val andChar: Functor[AndChar] = semiauto.functor
+    implicit val interleaved: Functor[Interleaved] = semiauto.functor
+    implicit val nestedPred: Functor[NestedPred] = semiauto.functor
+  }
+}

--- a/core/src/test/scala/cats/derived/hash.scala
+++ b/core/src/test/scala/cats/derived/hash.scala
@@ -5,6 +5,7 @@ import cats.kernel.laws.discipline.{HashTests, SerializableTests}
 import cats.instances.all._
 
 class HashSuite extends KittensSuite {
+  import HashSuite._
   import TestDefns._
 
   def testHash(context: String)(
@@ -35,15 +36,21 @@ class HashSuite extends KittensSuite {
     testHash("cached")
   }
 
-  semiTests.run()
+  {
+    import semiInstances._
+    testHash("semiauto")
+  }
+}
 
-  object semiTests {
-    implicit val iList: Hash[IList[Int]] = semi.hash
-    implicit val inner: Hash[Inner] = semi.hash
-    implicit val outer: Hash[Outer] = semi.hash
-    implicit val interleaved: Hash[Interleaved[Int]] = semi.hash
-    implicit val tree: Hash[Tree[Int]] = semi.hash
-    implicit val recursive: Hash[Recursive] = semi.hash
-    def run(): Unit = testHash("semi")
+object HashSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val iList: Hash[IList[Int]] = semiauto.hash
+    implicit val inner: Hash[Inner] = semiauto.hash
+    implicit val outer: Hash[Outer] = semiauto.hash
+    implicit val interleaved: Hash[Interleaved[Int]] = semiauto.hash
+    implicit val tree: Hash[Tree[Int]] = semiauto.hash
+    implicit val recursive: Hash[Recursive] = semiauto.hash
   }
 }

--- a/core/src/test/scala/cats/derived/invariant.scala
+++ b/core/src/test/scala/cats/derived/invariant.scala
@@ -24,15 +24,9 @@ import cats.laws.discipline.eq._
 import cats.laws.discipline._
 
 class InvariantSuite extends KittensSuite {
+  import InvariantSuite._
   import TestDefns._
   import TestEqInstances._
-
-  type ListSnoc[A] = List[Snoc[A]]
-  type GenericAdtF[A] = GenericAdt[A => Boolean]
-  type ListFToInt[A] = List[Snoc[A => Int]]
-  type InterleavedF[A] = Interleaved[A => Boolean]
-  type AndCharF[A] = (A => Boolean, Char)
-  type TreeF[A] = Tree[A => Boolean]
 
   def testInvariant(context: String)(
     implicit
@@ -76,20 +70,31 @@ class InvariantSuite extends KittensSuite {
     testInvariant("cached")
   }
 
-  semiTests.run()
-
-  object semiTests {
-    implicit val gadt: Invariant[GenericAdtF] = semi.invariant[GenericAdtF]
-    implicit val listSnocendo: Invariant[ListFToInt] = semi.invariant[ListFToInt]
-    implicit val interleaveF: Invariant[InterleavedF] = semi.invariant[InterleavedF]
-    implicit val andCharF: Invariant[AndCharF] = semi.invariant[AndCharF]
-    implicit val treeF: Invariant[TreeF] = semi.invariant[TreeF]
-    implicit val pred: Invariant[Pred] = semi.invariant[Pred]
-    implicit val snoc: Invariant[ListSnoc] = semi.invariant[ListSnoc]
-    implicit val bivariant: Invariant[Bivariant] = semi.invariant[Bivariant]
-    implicit val ilist: Invariant[IList] = semi.invariant[IList]
-
-    def run(): Unit = testInvariant("semi")
+  {
+    import semiInstances._
+    testInvariant("semiauto")
   }
 }
 
+object InvariantSuite {
+  import TestDefns._
+
+  type ListSnoc[A] = List[Snoc[A]]
+  type GenericAdtF[A] = GenericAdt[A => Boolean]
+  type ListFToInt[A] = List[Snoc[A => Int]]
+  type InterleavedF[A] = Interleaved[A => Boolean]
+  type AndCharF[A] = (A => Boolean, Char)
+  type TreeF[A] = Tree[A => Boolean]
+
+  object semiInstances {
+    implicit val gadt: Invariant[GenericAdtF] = semiauto.invariant[GenericAdtF]
+    implicit val listSnocendo: Invariant[ListFToInt] = semiauto.invariant[ListFToInt]
+    implicit val interleaveF: Invariant[InterleavedF] = semiauto.invariant[InterleavedF]
+    implicit val andCharF: Invariant[AndCharF] = semiauto.invariant[AndCharF]
+    implicit val treeF: Invariant[TreeF] = semiauto.invariant[TreeF]
+    implicit val pred: Invariant[Pred] = semiauto.invariant[Pred]
+    implicit val snoc: Invariant[ListSnoc] = semiauto.invariant[ListSnoc]
+    implicit val bivariant: Invariant[Bivariant] = semiauto.invariant[Bivariant]
+    implicit val ilist: Invariant[IList] = semiauto.invariant[IList]
+  }
+}

--- a/core/src/test/scala/cats/derived/iterable.scala
+++ b/core/src/test/scala/cats/derived/iterable.scala
@@ -91,7 +91,7 @@ class IterableSuite extends KittensSuite {
 
   test("Interleaved[T] => Iterable[T]") {
     val interleaved = Interleaved(42, 313, 3, List(1, 2, 3, 5, 7), "kittens")
-    val i = semi.iterable[TestDefns.Interleaved, Int](interleaved)
+    val i = semiauto.iterable[TestDefns.Interleaved, Int](interleaved)
     assert(i.toList == List(313, 1, 2, 3, 5, 7))
   }
 }

--- a/core/src/test/scala/cats/derived/monoid.scala
+++ b/core/src/test/scala/cats/derived/monoid.scala
@@ -55,15 +55,20 @@ class MonoidSuite extends KittensSuite {
   }
 
   {
-    implicit val foo: Monoid[Foo] = semi.monoid
-    implicit lazy val recursive: Monoid[Recursive] = semi.monoid
-    implicit val interleaved: Monoid[Interleaved[Int]] = semi.monoid
-    implicit val box: Monoid[Box[Mul]] = semi.monoid
-    testMonoid("semi")
+    import semiInstances._
+    testMonoid("semiauto")
   }
 }
 
 object MonoidSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val foo: Monoid[Foo] = semiauto.monoid
+    implicit lazy val recursive: Monoid[Recursive] = semiauto.monoid
+    implicit val interleaved: Monoid[Interleaved[Int]] = semiauto.monoid
+    implicit val box: Monoid[Box[Mul]] = semiauto.monoid
+  }
 
   final case class Mul(value: Int)
   object Mul {

--- a/core/src/test/scala/cats/derived/monoidk.scala
+++ b/core/src/test/scala/cats/derived/monoidk.scala
@@ -26,8 +26,6 @@ class MonoidKSuite extends KittensSuite {
   import TestDefns._
   import TestEqInstances._
 
-  type BoxMul[A] = Box[Mul[A]]
-
   def testMonoidK(context: String)(
     implicit complexProduct: MonoidK[ComplexProduct],
     caseClassWOption: MonoidK[CaseClassWOption],
@@ -55,14 +53,21 @@ class MonoidKSuite extends KittensSuite {
   }
 
   {
-    implicit val complexProduct: MonoidK[ComplexProduct] = semi.monoidK
-    implicit val caseClassWOption: MonoidK[CaseClassWOption] = semi.monoidK
-    implicit val boxMul: MonoidK[BoxMul] = semi.monoidK
+    import semiInstances._
     testMonoidK("semi")
   }
 }
 
 object MonoidKSuite {
+  import TestDefns._
+
+  type BoxMul[A] = Box[Mul[A]]
+
+  object semiInstances {
+    implicit val complexProduct: MonoidK[ComplexProduct] = semiauto.monoidK
+    implicit val caseClassWOption: MonoidK[CaseClassWOption] = semiauto.monoidK
+    implicit val boxMul: MonoidK[BoxMul] = semiauto.monoidK
+  }
 
   final case class Mul[T](value: Int)
   object Mul {

--- a/core/src/test/scala/cats/derived/nonEmptyTraverse.scala
+++ b/core/src/test/scala/cats/derived/nonEmptyTraverse.scala
@@ -95,7 +95,7 @@ class NonEmptyTraverseSuite extends KittensSuite {
 
   {
     import semiInstances._
-    testReducible("semi")
+    testReducible("semiauto")
   }
 }
 
@@ -107,11 +107,11 @@ object NonEmptyTraverseSuite {
   type ListAndNel[A] = (List[A], NonEmptyList[A])
 
   object semiInstances {
-    implicit val iCons: NonEmptyTraverse[ICons] = semi.nonEmptyTraverse
-    implicit val tree: NonEmptyTraverse[Tree] = semi.nonEmptyTraverse
-    implicit val nelSCons: NonEmptyTraverse[NelSCons] = semi.nonEmptyTraverse
-    implicit val nelAndOne: NonEmptyTraverse[NelAndOne] = semi.nonEmptyTraverse
-    implicit val listAndNel: NonEmptyTraverse[ListAndNel] = semi.nonEmptyTraverse
-    implicit val interleaved: NonEmptyTraverse[Interleaved] = semi.nonEmptyTraverse
+    implicit val iCons: NonEmptyTraverse[ICons] = semiauto.nonEmptyTraverse
+    implicit val tree: NonEmptyTraverse[Tree] = semiauto.nonEmptyTraverse
+    implicit val nelSCons: NonEmptyTraverse[NelSCons] = semiauto.nonEmptyTraverse
+    implicit val nelAndOne: NonEmptyTraverse[NelAndOne] = semiauto.nonEmptyTraverse
+    implicit val listAndNel: NonEmptyTraverse[ListAndNel] = semiauto.nonEmptyTraverse
+    implicit val interleaved: NonEmptyTraverse[Interleaved] = semiauto.nonEmptyTraverse
   }
 }

--- a/core/src/test/scala/cats/derived/order.scala
+++ b/core/src/test/scala/cats/derived/order.scala
@@ -21,6 +21,7 @@ import cats.kernel.laws.discipline.{OrderTests, SerializableTests}
 import cats.instances.all._
 
 class OrderSuite extends KittensSuite {
+  import OrderSuite._
   import TestDefns._
 
   def testOrder(context: String)(
@@ -48,14 +49,20 @@ class OrderSuite extends KittensSuite {
     testOrder("cached")
   }
 
-  semiTests.run()
+  {
+    import semiInstances._
+    testOrder("semiauto")
+  }
+}
 
-  object semiTests {
-    implicit val inner: Order[Inner] = semi.order
-    implicit val outer: Order[Outer] = semi.order
-    implicit val interleaved: Order[Interleaved[Int]] = semi.order
-    implicit val recursive: Order[Recursive] = semi.order
-    implicit val genericAdt: Order[GenericAdt[Int]] = semi.order
-    def run(): Unit = testOrder("semi")
+object OrderSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val inner: Order[Inner] = semiauto.order
+    implicit val outer: Order[Outer] = semiauto.order
+    implicit val interleaved: Order[Interleaved[Int]] = semiauto.order
+    implicit val recursive: Order[Recursive] = semiauto.order
+    implicit val genericAdt: Order[GenericAdt[Int]] = semiauto.order
   }
 }

--- a/core/src/test/scala/cats/derived/partialOrder.scala
+++ b/core/src/test/scala/cats/derived/partialOrder.scala
@@ -62,21 +62,24 @@ class PartialOrderSuite extends KittensSuite {
     testPartialOrder("cached")
   }
 
-  semiTests.run()
-
-  object semiTests {
-    implicit val iList: PartialOrder[IList[Int]] = semi.partialOrder
-    implicit val inner: PartialOrder[Inner] = semi.partialOrder
-    implicit val outer: PartialOrder[Outer] = semi.partialOrder
-    implicit val interleaved: PartialOrder[Interleaved[Int]] = semi.partialOrder
-    implicit val tree: PartialOrder[Tree[Int]] = semi.partialOrder
-    implicit val recursive: PartialOrder[Recursive] = semi.partialOrder
-    implicit val boxKeyValue: PartialOrder[Box[KeyValue]] = semi.partialOrder
-    def run(): Unit = testPartialOrder("semi")
+  {
+    import semiInstances._
+    testPartialOrder("semiauto")
   }
 }
 
 object PartialOrderSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val iList: PartialOrder[IList[Int]] = semiauto.partialOrder
+    implicit val inner: PartialOrder[Inner] = semiauto.partialOrder
+    implicit val outer: PartialOrder[Outer] = semiauto.partialOrder
+    implicit val interleaved: PartialOrder[Interleaved[Int]] = semiauto.partialOrder
+    implicit val tree: PartialOrder[Tree[Int]] = semiauto.partialOrder
+    implicit val recursive: PartialOrder[Recursive] = semiauto.partialOrder
+    implicit val boxKeyValue: PartialOrder[Box[KeyValue]] = semiauto.partialOrder
+  }
 
   final case class KeyValue(key: String, value: Int)
   object KeyValue extends ((String, Int) => KeyValue) {

--- a/core/src/test/scala/cats/derived/pure.scala
+++ b/core/src/test/scala/cats/derived/pure.scala
@@ -27,11 +27,6 @@ class PureSuite extends KittensSuite {
   import PureSuite._
   import TestDefns._
 
-  type LOption[A] = List[Option[A]]
-  type PList[A] = (List[A], List[A])
-  type NelOption[A] = NonEmptyList[Option[A]]
-  type BoxColor[A] = Box[Color[A]]
-
   def testPure(context: String)(
     implicit lOption: Pure[LOption],
     pList: Pure[PList],
@@ -64,19 +59,29 @@ class PureSuite extends KittensSuite {
   }
 
   {
-    implicit val lOption: Pure[LOption] = semi.pure
-    implicit val pList: Pure[PList] = semi.pure
-    implicit val caseClassWOption: Pure[CaseClassWOption] = semi.pure
-    implicit val nelOption: Pure[NelOption] = semi.pure
-    implicit val interleaved: Pure[Interleaved] = semi.pure
-    implicit val boxColor: Pure[BoxColor] = semi.pure
-    testPure("semi")
-    illTyped("semi.pure[IList]")
-    illTyped("semi.pure[Snoc]")
+    import semiInstances._
+    testPure("semiauto")
+    illTyped("semiauto.pure[IList]")
+    illTyped("semiauto.pure[Snoc]")
   }
 }
 
 object PureSuite {
+  import TestDefns._
+
+  type LOption[A] = List[Option[A]]
+  type PList[A] = (List[A], List[A])
+  type NelOption[A] = NonEmptyList[Option[A]]
+  type BoxColor[A] = Box[Color[A]]
+
+  object semiInstances {
+    implicit val lOption: Pure[LOption] = semiauto.pure
+    implicit val pList: Pure[PList] = semiauto.pure
+    implicit val caseClassWOption: Pure[CaseClassWOption] = semiauto.pure
+    implicit val nelOption: Pure[NelOption] = semiauto.pure
+    implicit val interleaved: Pure[Interleaved] = semiauto.pure
+    implicit val boxColor: Pure[BoxColor] = semiauto.pure
+  }
 
   final case class Color[A](r: Int, g: Int, b: Int)
   object Color {

--- a/core/src/test/scala/cats/derived/reducible.scala
+++ b/core/src/test/scala/cats/derived/reducible.scala
@@ -85,7 +85,7 @@ class ReducibleSuite extends KittensSuite {
 
   {
     import semiInstances._
-    testReducible("semi")
+    testReducible("semiauto")
   }
 }
 
@@ -98,13 +98,13 @@ object ReducibleSuite {
   type BoxZipper[A] = Box[Zipper[A]]
 
   object semiInstances {
-    implicit val iCons: Reducible[ICons] = semi.reducible
-    implicit val tree: Reducible[Tree] = semi.reducible
-    implicit val nelSCons: Reducible[NelSCons] = semi.reducible
-    implicit val nelAndOne: Reducible[NelAndOne] = semi.reducible
-    implicit val listAndNel: Reducible[ListAndNel] = semi.reducible
-    implicit val interleaved: Reducible[Interleaved] = semi.reducible
-    implicit val boxZipper: Reducible[BoxZipper] = semi.reducible
+    implicit val iCons: Reducible[ICons] = semiauto.reducible
+    implicit val tree: Reducible[Tree] = semiauto.reducible
+    implicit val nelSCons: Reducible[NelSCons] = semiauto.reducible
+    implicit val nelAndOne: Reducible[NelAndOne] = semiauto.reducible
+    implicit val listAndNel: Reducible[ListAndNel] = semiauto.reducible
+    implicit val interleaved: Reducible[Interleaved] = semiauto.reducible
+    implicit val boxZipper: Reducible[BoxZipper] = semiauto.reducible
   }
 
   final case class Zipper[+A](left: List[A], focus: A, right: List[A])

--- a/core/src/test/scala/cats/derived/semigroup.scala
+++ b/core/src/test/scala/cats/derived/semigroup.scala
@@ -54,15 +54,20 @@ class SemigroupSuite extends KittensSuite {
   }
 
   {
-    implicit val foo: Semigroup[Foo] = semi.semigroup
-    implicit lazy val recursive: Semigroup[Recursive] = semi.semigroup
-    implicit val interleaved: Semigroup[Interleaved[Int]] = semi.semigroup
-    implicit val box: Semigroup[Box[Mul]] = semi.semigroup
-    testSemigroup("semi")
+    import semiInstances._
+    testSemigroup("semiauto")
   }
 }
 
 object SemigroupSuite {
+  import TestDefns._
+
+  object semiInstances {
+    implicit val foo: Semigroup[Foo] = semiauto.semigroup
+    implicit lazy val recursive: Semigroup[Recursive] = semiauto.semigroup
+    implicit val interleaved: Semigroup[Interleaved[Int]] = semiauto.semigroup
+    implicit val box: Semigroup[Box[Mul]] = semiauto.semigroup
+  }
 
   final case class Mul(value: Int)
   object Mul {

--- a/core/src/test/scala/cats/derived/semigroupk.scala
+++ b/core/src/test/scala/cats/derived/semigroupk.scala
@@ -26,8 +26,6 @@ class SemigroupKSuite extends KittensSuite {
   import TestDefns._
   import TestEqInstances._
 
-  type BoxMul[A] = Box[Mul[A]]
-
   def testSemigroupK(context: String)(
     implicit complexProduct: SemigroupK[ComplexProduct],
     caseClassWOption: SemigroupK[CaseClassWOption],
@@ -54,14 +52,21 @@ class SemigroupKSuite extends KittensSuite {
   }
 
   {
-    implicit val complexProduct: SemigroupK[ComplexProduct] = semi.semigroupK
-    implicit val caseClassWOption: SemigroupK[CaseClassWOption] = semi.semigroupK
-    implicit val boxMul: SemigroupK[BoxMul] = semi.semigroupK
-    testSemigroupK("semi")
+    import semiInstances._
+    testSemigroupK("semiauto")
   }
 }
 
 object SemigroupKSuite {
+  import TestDefns._
+
+  type BoxMul[A] = Box[Mul[A]]
+
+  object semiInstances {
+    implicit val complexProduct: SemigroupK[ComplexProduct] = semiauto.semigroupK
+    implicit val caseClassWOption: SemigroupK[CaseClassWOption] = semiauto.semigroupK
+    implicit val boxMul: SemigroupK[BoxMul] = semiauto.semigroupK
+  }
 
   final case class Mul[T](value: Int)
   object Mul {

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -84,8 +84,8 @@ class ShowSuite extends KittensSuite {
 
   {
     import semiInstances._
-    testShow("semi")
     illTyped("semi.show[Tree[Int]]")
+    testShow("semiauto")
   }
 }
 
@@ -102,14 +102,14 @@ object ShowSuite {
   }
 
   object semiInstances {
-    implicit val foo: Show[Foo] = semi.show
-    implicit val outer: Show[Outer] = semi.show
-    implicit val intTree: Show[IntTree] = semi.show
-    implicit val genericAdt: Show[GenericAdt[Int]] = semi.show
-    implicit val people: Show[People] = semi.show
-    implicit val listFieldChild: Show[ListFieldChild] = semi.show
-    implicit val listField: Show[ListField] = semi.show
-    implicit val interleaved: Show[Interleaved[Int]] = semi.show
-    implicit val boxBogus: Show[Box[Bogus]] = semi.show
+    implicit val foo: Show[Foo] = semiauto.show
+    implicit val outer: Show[Outer] = semiauto.show
+    implicit val intTree: Show[IntTree] = semiauto.show
+    implicit val genericAdt: Show[GenericAdt[Int]] = semiauto.show
+    implicit val people: Show[People] = semiauto.show
+    implicit val listFieldChild: Show[ListFieldChild] = semiauto.show
+    implicit val listField: Show[ListField] = semiauto.show
+    implicit val interleaved: Show[Interleaved[Int]] = semiauto.show
+    implicit val boxBogus: Show[Box[Bogus]] = semiauto.show
   }
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -153,8 +153,8 @@ class ShowPrettySuite extends KittensSuite {
 
   {
     import semiInstances._
-    testShowPretty("semi")
     illTyped("semi.showPretty[Tree[Int]]")
+    testShowPretty("semiauto")
   }
 }
 
@@ -171,14 +171,14 @@ object ShowPrettySuite {
   }
 
   object semiInstances {
-    implicit val foo: ShowPretty[Foo] = semi.showPretty
-    implicit val outer: ShowPretty[Outer] = semi.showPretty
-    implicit val intTree: ShowPretty[IntTree] = semi.showPretty
-    implicit val genericAdt: ShowPretty[GenericAdt[Int]] = semi.showPretty
-    implicit val people: ShowPretty[People] = semi.showPretty
-    implicit val listFieldChild: ShowPretty[ListFieldChild] = semi.showPretty
-    implicit val listField: ShowPretty[ListField] = semi.showPretty
-    implicit val interleaved: ShowPretty[Interleaved[Int]] = semi.showPretty
-    implicit val boxBogus: ShowPretty[Box[Bogus]] = semi.showPretty
+    implicit val foo: ShowPretty[Foo] = semiauto.showPretty
+    implicit val outer: ShowPretty[Outer] = semiauto.showPretty
+    implicit val intTree: ShowPretty[IntTree] = semiauto.showPretty
+    implicit val genericAdt: ShowPretty[GenericAdt[Int]] = semiauto.showPretty
+    implicit val people: ShowPretty[People] = semiauto.showPretty
+    implicit val listFieldChild: ShowPretty[ListFieldChild] = semiauto.showPretty
+    implicit val listField: ShowPretty[ListField] = semiauto.showPretty
+    implicit val interleaved: ShowPretty[Interleaved[Int]] = semiauto.showPretty
+    implicit val boxBogus: ShowPretty[Box[Bogus]] = semiauto.showPretty
   }
 }

--- a/core/src/test/scala/cats/derived/traverse.scala
+++ b/core/src/test/scala/cats/derived/traverse.scala
@@ -7,10 +7,7 @@ import cats.laws.discipline.{SerializableTests, TraverseTests}
 class TraverseSuite extends KittensSuite {
   import TestDefns._
   import TestEqInstances._
-
-  type OptList[A] = Option[List[A]]
-  type ListSnoc[A] = List[Snoc[A]]
-  type AndChar[A] = (A, Char)
+  import TraverseSuite._
 
   def testTraverse(context: String)(
     implicit iList: Traverse[IList],
@@ -69,17 +66,26 @@ class TraverseSuite extends KittensSuite {
     testTraverse("cached")
   }
 
-  semiTests.run()
-
-  object semiTests {
-    implicit val iList: Traverse[IList] = semi.traverse
-    implicit val tree: Traverse[Tree] = semi.traverse
-    implicit val genericAdt: Traverse[GenericAdt] = semi.traverse
-    implicit val optList: Traverse[OptList] = semi.traverse
-    implicit val listSnoc: Traverse[ListSnoc] = semi.traverse
-    implicit val andChar: Traverse[AndChar] = semi.traverse
-    implicit val interleaved: Traverse[Interleaved] = semi.traverse
-    def run(): Unit = testTraverse("semi")
+  {
+    import semiInstances._
+    testTraverse("semiauto")
   }
 }
 
+object TraverseSuite {
+  import TestDefns._
+
+  type OptList[A] = Option[List[A]]
+  type ListSnoc[A] = List[Snoc[A]]
+  type AndChar[A] = (A, Char)
+
+  object semiInstances {
+    implicit val iList: Traverse[IList] = semiauto.traverse
+    implicit val tree: Traverse[Tree] = semiauto.traverse
+    implicit val genericAdt: Traverse[GenericAdt] = semiauto.traverse
+    implicit val optList: Traverse[OptList] = semiauto.traverse
+    implicit val listSnoc: Traverse[ListSnoc] = semiauto.traverse
+    implicit val andChar: Traverse[AndChar] = semiauto.traverse
+    implicit val interleaved: Traverse[Interleaved] = semiauto.traverse
+  }
+}


### PR DESCRIPTION
`semiauto` doesn't use `Lazy`.

That improves compile time performance marginally and has better error messages on Scala 2.13.
Moved `semiauto` test instances to companion objects to ensure serializability.

This would have to go into a 2.1.0 release.