### PR TITLE
Add implicitNotFound error message for 2.13 Lazy version

### DIFF
--- a/core/src/main/scala-2.13/cats/derived/util/versionspecific.scala
+++ b/core/src/main/scala-2.13/cats/derived/util/versionspecific.scala
@@ -1,5 +1,6 @@
 package cats.derived.util
 
+import scala.annotation.implicitNotFound
 import scala.util.hashing.MurmurHash3
 
 object VersionSpecific {
@@ -7,6 +8,7 @@ object VersionSpecific {
   private[derived] def productSeed(x: Product): Int =
     MurmurHash3.mix(MurmurHash3.productSeed, x.productPrefix.hashCode)
 
+  @implicitNotFound("could not find Lazy implicit value of type ${A}")
   abstract class Lazy[+A] extends Serializable {
     def value(): A
   }


### PR DESCRIPTION
Unfortunately in this version of `Lazy` we can't show the original
implicit not found error message of `A` because it's not a macro.

The error message is the same as in shapeless.