### PR TITLE
Enable illTyped tests that were broken on Scala 2.13.0

### DIFF
--- a/core/src/test/scala/cats/derived/empty.scala
+++ b/core/src/test/scala/cats/derived/empty.scala
@@ -59,22 +59,25 @@ class EmptySuite extends KittensSuite {
   {
     import auto.empty._
     testEmpty("auto")
-    // NOTE: These typecheck but crash the compiler on Scala 2.13
-//    println(Empty[IList[Int]])
-//    println(Empty[Snoc[Int]])
+    illTyped("Empty[IList[Int]]")
+    illTyped("Empty[Snoc[Int]]")
     illTyped("Empty[Rgb]")
   }
 
   {
     import cached.empty._
     testEmpty("cached")
-    // NOTE: These typecheck but crash the compiler on Scala 2.13
-//    println(Empty[IList[Int]])
-//    println(Empty[Snoc[Int]])
+    illTyped("Empty[IList[Int]]")
+    illTyped("Empty[Snoc[Int]]")
     illTyped("Empty[Rgb]")
   }
 
-  semiTests.run()
+  {
+    semiTests.run()
+    illTyped("semi.empty[IList[Int]]")
+    illTyped("semi.empty[Snoc[Int]]")
+    illTyped("semi.empty[Rgb]")
+  }
 
   object semiTests {
     implicit val foo: Empty[Foo] = semi.empty
@@ -85,10 +88,6 @@ class EmptySuite extends KittensSuite {
     implicit val snoc: Empty[Snoc[Dummy]] = semi.empty
     implicit val box: Empty[Box[Mask]] = semi.empty
     implicit val chain: Empty[Chain] = semi.empty
-    // NOTE: These typecheck but crash the compiler on Scala 2.13
-//    println(semi.empty[IList[Int]])
-//    println(semi.empty[Snoc[Int]])
-    illTyped("semi.empty[Rgb]")
     def run(): Unit = testEmpty("semi")
   }
 }

--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -3,6 +3,7 @@ package derived
 
 import cats.instances.all._
 import cats.laws.discipline.SerializableTests
+import shapeless.test.illTyped
 
 class ShowSuite extends KittensSuite {
   import ShowSuite._
@@ -72,20 +73,19 @@ class ShowSuite extends KittensSuite {
   {
     import auto.show._
     testShow("auto")
-    // NOTE: This typechecks but crashes the compiler on Scala 2.13
-//    println(Show[Tree[Int]])
+    illTyped("Show[Tree[Int]]")
   }
 
   {
     import cached.show._
     testShow("cached")
-    // NOTE: This typechecks but crashes the compiler on Scala 2.13
-//    println(Show[Tree[Int]])
+    illTyped("Show[Tree[Int]]")
   }
 
   {
     import semiInstances._
     testShow("semi")
+    illTyped("semi.show[Tree[Int]]")
   }
 }
 
@@ -111,7 +111,5 @@ object ShowSuite {
     implicit val listField: Show[ListField] = semi.show
     implicit val interleaved: Show[Interleaved[Int]] = semi.show
     implicit val boxBogus: Show[Box[Bogus]] = semi.show
-    // NOTE: This typechecks but crashes the compiler on Scala 2.13
-    //    println(semi.show[Tree[Int]])
   }
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -3,6 +3,7 @@ package derived
 
 import cats.instances.all._
 import cats.laws.discipline.SerializableTests
+import shapeless.test.illTyped
 
 class ShowPrettySuite extends KittensSuite {
   import ShowPrettySuite._
@@ -141,20 +142,19 @@ class ShowPrettySuite extends KittensSuite {
   {
     import auto.showPretty._
     testShowPretty("auto")
-    // NOTE: This typechecks but crashes the compiler on Scala 2.13
-//    println(ShowPretty[Tree[Int]])
+    illTyped("ShowPretty[Tree[Int]]")
   }
 
   {
     import cached.showPretty._
     testShowPretty("cached")
-    // NOTE: This typechecks but crashes the compiler on Scala 2.13
-//    println(ShowPretty[Tree[Int]])
+    illTyped("ShowPretty[Tree[Int]]")
   }
 
   {
     import semiInstances._
     testShowPretty("semi")
+    illTyped("semi.showPretty[Tree[Int]]")
   }
 }
 
@@ -180,7 +180,5 @@ object ShowPrettySuite {
     implicit val listField: ShowPretty[ListField] = semi.showPretty
     implicit val interleaved: ShowPretty[Interleaved[Int]] = semi.showPretty
     implicit val boxBogus: ShowPretty[Box[Bogus]] = semi.showPretty
-    // NOTE: This typechecks but crashes the compiler on Scala 2.13
-    //    println(semi.showPretty[Tree[Int]])
   }
 }


### PR DESCRIPTION
The bug was fixed in Scala 2.13.1