### PR TITLE
Scala 2.12.12 and 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: scala
 
 scala:
-- 2.12.11
-- 2.13.2
+- 2.12.12
+- 2.13.3
 
 jdk:
 - openjdk8
 
 cache:
   directories:
+  - "$HOME/.cache/coursier"
   - "$HOME/.ivy2/cache"
   - "$HOME/.sbt"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
 lazy val buildSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.13.2",
-  crossScalaVersions := Seq("2.12.11", scalaVersion.value)
+  scalaVersion := "2.13.3",
+  crossScalaVersions := Seq("2.12.12", scalaVersion.value)
 )
 
 val catsVersion = "2.1.1"
@@ -18,7 +18,8 @@ lazy val commonSettings = Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
     "-unchecked",
-    "-deprecation"
+    "-deprecation",
+    "-Xfatal-warnings"
   ),
   scalacOptions ++= (
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/core/src/main/scala-2.13/cats/derived/util/versionspecific.scala
+++ b/core/src/main/scala-2.13/cats/derived/util/versionspecific.scala
@@ -10,11 +10,13 @@ object VersionSpecific {
 
   @implicitNotFound("could not find Lazy implicit value of type ${A}")
   abstract class Lazy[+A] extends Serializable {
-    def value(): A
+    def value: A
   }
 
   object Lazy {
-    implicit def instance[A](implicit ev: => A): Lazy[A] = () => ev
+    implicit def instance[A](implicit ev: => A): Lazy[A] = new Lazy[A] {
+      def value: A = ev
+    }
   }
 
   sealed trait OrElse[+A, +B] extends Serializable {

--- a/core/src/main/scala/cats/derived/iterable.scala
+++ b/core/src/main/scala/cats/derived/iterable.scala
@@ -49,14 +49,14 @@ trait MkIterable[F[_]] {
           }
       }
 
-      def next: A =
+      def next(): A =
         if (!hasNext) Iterator.empty.next()
         else (first: @unchecked) match {
           case IterState.Return(a) =>
             first = IterState.Done
             a
           case IterState.Iterate(it) =>
-            it.next
+            it.next()
         }
     }
   }


### PR DESCRIPTION
 * Fix `Lazy` auto-application warnings on 2.13
 * Enable `-Xfatal-warnings`
 * Cache Coursier directory on CI