### PR TITLE
Switch Show and PrettyShow from Typeable to ClassTag

### DIFF
--- a/core/src/test/scala/cats/derived/show.scala
+++ b/core/src/test/scala/cats/derived/show.scala
@@ -1,7 +1,7 @@
 package cats
 package derived
+
 import cats.laws.discipline.SerializableTests
-import shapeless.test.illTyped
 
 class ShowSuite extends KittensSuite {
   import ShowSuite._
@@ -15,6 +15,7 @@ class ShowSuite extends KittensSuite {
       people: Show[People],
       listField: Show[ListField],
       interleaved: Show[Interleaved[Int]],
+      tree: Show[Tree[Int]],
       boxBogus: Show[Box[Bogus]]
   ): Unit = {
     checkAll(s"$context.Show is Serializable", SerializableTests.serializable(Show[IntTree]))
@@ -63,6 +64,13 @@ class ShowSuite extends KittensSuite {
       assert(value.show == shown)
     }
 
+    test(s"$context.Show[Tree[Int]]") {
+      val value: Tree[Int] = Node(Leaf(1), Node(Node(Leaf(2), Leaf(3)), Leaf(4)))
+      val shown =
+        "Node(left = Leaf(value = 1), right = Node(left = Node(left = Leaf(value = 2), right = Leaf(value = 3)), right = Leaf(value = 4)))"
+      assert(value.show == shown)
+    }
+
     test(s"$context.Show respects existing instances") {
       val value = Box(Bogus(42))
       val shown = "Box(content = Blah)"
@@ -73,18 +81,15 @@ class ShowSuite extends KittensSuite {
   {
     import auto.show._
     testShow("auto")
-    illTyped("Show[Tree[Int]]")
   }
 
   {
     import cached.show._
     testShow("cached")
-    illTyped("Show[Tree[Int]]")
   }
 
   {
     import semiInstances._
-    illTyped("semi.show[Tree[Int]]")
     testShow("semiauto")
   }
 }
@@ -110,6 +115,7 @@ object ShowSuite {
     implicit val listFieldChild: Show[ListFieldChild] = semiauto.show
     implicit val listField: Show[ListField] = semiauto.show
     implicit val interleaved: Show[Interleaved[Int]] = semiauto.show
+    implicit val tree: Show[Tree[Int]] = semiauto.show
     implicit val boxBogus: Show[Box[Bogus]] = semiauto.show
   }
 }

--- a/core/src/test/scala/cats/derived/showPretty.scala
+++ b/core/src/test/scala/cats/derived/showPretty.scala
@@ -1,7 +1,7 @@
 package cats
 package derived
+
 import cats.laws.discipline.SerializableTests
-import shapeless.test.illTyped
 
 class ShowPrettySuite extends KittensSuite {
   import ShowPrettySuite._
@@ -15,6 +15,7 @@ class ShowPrettySuite extends KittensSuite {
       people: ShowPretty[People],
       listField: ShowPretty[ListField],
       interleaved: ShowPretty[Interleaved[Int]],
+      tree: ShowPretty[Tree[Int]],
       boxBogus: ShowPretty[Box[Bogus]]
   ): Unit = {
     checkAll(s"$context.ShowPretty is Serializable", SerializableTests.serializable(ShowPretty[IntTree]))
@@ -125,6 +126,32 @@ class ShowPrettySuite extends KittensSuite {
       assert(value.show == pretty)
     }
 
+    test(s"$context.ShowPretty[Tree[Int]]") {
+      val value: Tree[Int] = Node(Leaf(1), Node(Node(Leaf(2), Leaf(3)), Leaf(4)))
+      val pretty = """
+        |Node(
+        |  left = Leaf(
+        |    value = 1
+        |  ),
+        |  right = Node(
+        |    left = Node(
+        |      left = Leaf(
+        |        value = 2
+        |      ),
+        |      right = Leaf(
+        |        value = 3
+        |      )
+        |    ),
+        |    right = Leaf(
+        |      value = 4
+        |    )
+        |  )
+        |)
+      """.stripMargin.trim
+
+      assert(value.show == pretty)
+    }
+
     test(s"$context.ShowPretty respects existing instances") {
       val value = Box(Bogus(42))
       val pretty = """
@@ -140,18 +167,15 @@ class ShowPrettySuite extends KittensSuite {
   {
     import auto.showPretty._
     testShowPretty("auto")
-    illTyped("ShowPretty[Tree[Int]]")
   }
 
   {
     import cached.showPretty._
     testShowPretty("cached")
-    illTyped("ShowPretty[Tree[Int]]")
   }
 
   {
     import semiInstances._
-    illTyped("semi.showPretty[Tree[Int]]")
     testShowPretty("semiauto")
   }
 }
@@ -177,6 +201,7 @@ object ShowPrettySuite {
     implicit val listFieldChild: ShowPretty[ListFieldChild] = semiauto.showPretty
     implicit val listField: ShowPretty[ListField] = semiauto.showPretty
     implicit val interleaved: ShowPretty[Interleaved[Int]] = semiauto.showPretty
+    implicit val tree: ShowPretty[Tree[Int]] = semiauto.showPretty
     implicit val boxBogus: ShowPretty[Box[Bogus]] = semiauto.showPretty
   }
 }


### PR DESCRIPTION
We're not using any special features of `Typeable`
(e.g. we are not showing the type parameters)
that are not provided by `ClassTag`.

But it is confusing to users when there is no `Typeable` instance.
Fixes #267