### PR TITLE
Further simplify Empty derivation

### DIFF
--- a/core/src/main/scala-3/cats/derived/empty.scala
+++ b/core/src/main/scala-3/cats/derived/empty.scala
@@ -13,16 +13,12 @@ trait DerivedEmpty[A] extends Empty[A]:
 object DerivedEmpty:
   inline given [A]: DerivedEmpty[A] = summonFrom {
     case given Empty[A] => delegated
-    case given K0.Generic[A] => derived
+    case given K0.ProductInstances[DerivedEmpty, A] => product
+    case given K0.CoproductGeneric[A] => coproduct
   }
   
   def delegated[A](using A: => Empty[A]): DerivedEmpty[A] =
     () => A.empty
-
-  inline def derived[A](using gen: K0.Generic[A]): DerivedEmpty[A] =
-    inline gen match
-      case given K0.ProductGeneric[A] => DerivedEmpty.product
-      case given K0.CoproductGeneric[A] => DerivedEmpty.coproduct
 
   def product[A](using inst: K0.ProductInstances[DerivedEmpty, A]): DerivedEmpty[A] =
     () => inst.construct([A] => (A: DerivedEmpty[A]) => A.empty)

--- a/core/src/main/scala-3/cats/derived/empty.scala
+++ b/core/src/main/scala-3/cats/derived/empty.scala
@@ -16,7 +16,7 @@ object DerivedEmpty:
     case given K0.Generic[A] => derived
   }
   
-  private def delegated[A](using A: => Empty[A]): DerivedEmpty[A] =
+  def delegated[A](using A: => Empty[A]): DerivedEmpty[A] =
     () => A.empty
 
   inline def derived[A](using gen: K0.Generic[A]): DerivedEmpty[A] =

--- a/core/src/main/scala-3/cats/derived/empty.scala
+++ b/core/src/main/scala-3/cats/derived/empty.scala
@@ -2,6 +2,7 @@ package cats.derived
 
 import alleycats.Empty
 import shapeless3.deriving.K0
+import scala.compiletime.summonFrom
 
 object empty extends EmptyDerivation
 
@@ -9,21 +10,25 @@ trait DerivedEmpty[A] extends Empty[A]:
   protected def emptyValue(): A
   lazy val empty: A = emptyValue()
 
-object DerivedEmpty extends DerivedEmptyLowPriority:
-  given delegated[A](using A: => Empty[A]): DerivedEmpty[A] =
+object DerivedEmpty:
+  inline given [A]: DerivedEmpty[A] = summonFrom {
+    case given Empty[A] => delegated
+    case given K0.Generic[A] => derived
+  }
+  
+  private def delegated[A](using A: => Empty[A]): DerivedEmpty[A] =
     () => A.empty
+
+  inline def derived[A](using gen: K0.Generic[A]): DerivedEmpty[A] =
+    inline gen match
+      case given K0.ProductGeneric[A] => DerivedEmpty.product
+      case given K0.CoproductGeneric[A] => DerivedEmpty.coproduct
 
   def product[A](using inst: K0.ProductInstances[DerivedEmpty, A]): DerivedEmpty[A] =
     () => inst.construct([A] => (A: DerivedEmpty[A]) => A.empty)
 
   inline def coproduct[A](using gen: K0.CoproductGeneric[A]): DerivedEmpty[A] =
     K0.summonFirst[DerivedEmpty, gen.MirroredElemTypes, A]
-
-private[derived] sealed abstract class DerivedEmptyLowPriority:
-  inline given derived[A](using gen: K0.Generic[A]): DerivedEmpty[A] =
-    inline gen match
-      case given K0.ProductGeneric[A] => DerivedEmpty.product
-      case given K0.CoproductGeneric[A] => DerivedEmpty.coproduct
 
 trait EmptyDerivation:
   extension (E: Empty.type)


### PR DESCRIPTION
This reduces indirection but I think also makes it clearer what's going on - I found it confusing that `derive` takes `Generic` as an argument but then delegates to `product` which takes `ProductInstances`.