### PR TITLE
Fix semigroup hierarchy derivation for recursive types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val catsVersion = "2.6.1"
 val disciplineMunitVersion = "1.0.9"
 val kindProjectorVersion = "0.13.0"
 val shapeless2Version = "2.3.7"
-val shapeless3Version = "3.0.3"
+val shapeless3Version = "3.0.4"
 
 lazy val commonSettings = Seq(
   scalacOptions := Seq(

--- a/core/src/main/scala-3/cats/derived/DerivedCommutativeMonoid.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedCommutativeMonoid.scala
@@ -12,7 +12,7 @@ object DerivedCommutativeMonoid:
     import DerivedCommutativeMonoid.given
     summonInline[DerivedCommutativeMonoid[A]].instance
 
-  given [A](using inst: K0.ProductInstances[Or, A]): DerivedCommutativeMonoid[A] =
+  given [A](using inst: => K0.ProductInstances[Or, A]): DerivedCommutativeMonoid[A] =
     given K0.ProductInstances[CommutativeMonoid, A] = inst.unify
     new Product[CommutativeMonoid, A] {}
 

--- a/core/src/main/scala-3/cats/derived/DerivedCommutativeSemigroup.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedCommutativeSemigroup.scala
@@ -12,7 +12,7 @@ object DerivedCommutativeSemigroup:
     import DerivedCommutativeSemigroup.given
     summonInline[DerivedCommutativeSemigroup[A]].instance
 
-  given [A](using inst: K0.ProductInstances[Or, A]): DerivedCommutativeSemigroup[A] =
+  given [A](using inst: => K0.ProductInstances[Or, A]): DerivedCommutativeSemigroup[A] =
     given K0.ProductInstances[CommutativeSemigroup, A] = inst.unify
     new Product[CommutativeSemigroup, A] {}
 

--- a/core/src/main/scala-3/cats/derived/DerivedMonoid.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedMonoid.scala
@@ -12,7 +12,7 @@ object DerivedMonoid:
     import DerivedMonoid.given
     summonInline[DerivedMonoid[A]].instance
 
-  given [A](using inst: K0.ProductInstances[Or, A]): DerivedMonoid[A] =
+  given [A](using inst: => K0.ProductInstances[Or, A]): DerivedMonoid[A] =
     given K0.ProductInstances[Monoid, A] = inst.unify
     new Product[Monoid, A] {}
 

--- a/core/src/main/scala-3/cats/derived/DerivedSemigroup.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedSemigroup.scala
@@ -12,7 +12,7 @@ object DerivedSemigroup:
     import DerivedSemigroup.given
     summonInline[DerivedSemigroup[A]].instance
 
-  given [A](using inst: K0.ProductInstances[Or, A]): DerivedSemigroup[A] =
+  given [A](using inst: => K0.ProductInstances[Or, A]): DerivedSemigroup[A] =
     given K0.ProductInstances[Semigroup, A] = inst.unify
     new Product[Semigroup, A] {}
 

--- a/core/src/test/scala-3/cats/derived/CommutativeMonoidSuite.scala
+++ b/core/src/test/scala-3/cats/derived/CommutativeMonoidSuite.scala
@@ -32,8 +32,7 @@ class CommutativeMonoidSuite extends KittensSuite:
 
   inline def testCommutativeMonoid(inline context: String): Unit =
     checkAll(s"$context.CommutativeMonoid[Foo]", commutativeMonoidTests[CommutativeFoo].commutativeMonoid)
-    // FIXME: Doesn't work
-    //checkAll(s"$context.CommutativeMonoid[Recursive]", commutativeMonoidTests[Recursive].commutativeMonoid)
+    checkAll(s"$context.CommutativeMonoid[Recursive]", commutativeMonoidTests[Recursive].commutativeMonoid)
     checkAll(s"$context.CommutativeMonoid[Box[Mul]]", commutativeMonoidTests[Box[Mul]].commutativeMonoid)
     checkAll(
       s"$context.CommutativeMonoid is Serializable",

--- a/core/src/test/scala-3/cats/derived/CommutativeSemigroupSuite.scala
+++ b/core/src/test/scala-3/cats/derived/CommutativeSemigroupSuite.scala
@@ -35,8 +35,7 @@ class CommutativeSemigroupSuite extends KittensSuite:
       s"$context.CommutativeSemigroup[CommutativeFoo]",
       commutativeSemigroupTests[CommutativeFoo].commutativeSemigroup
     )
-    // FIXME: Doesn't work
-    //checkAll(s"$context.CommutativeSemigroup[Recursive]", commutativeSemigroupTests[Recursive].commutativeSemigroup)
+    checkAll(s"$context.CommutativeSemigroup[Recursive]", commutativeSemigroupTests[Recursive].commutativeSemigroup)
     checkAll(s"$context.CommutativeSemigroup[Box[Mul]]", commutativeSemigroupTests[Box[Mul]].commutativeSemigroup)
     checkAll(
       s"$context.CommutativeSemigroup is Serializable",

--- a/core/src/test/scala-3/cats/derived/MonoidSuite.scala
+++ b/core/src/test/scala-3/cats/derived/MonoidSuite.scala
@@ -33,8 +33,7 @@ class MonoidSuite extends KittensSuite:
     checkAll(s"$context.Monoid[Foo]", monoidTests[Foo].monoid)
     checkAll(s"$context.Monoid[Interleaved[Int]]", monoidTests[Interleaved[Int]].monoid)
     checkAll(s"$context.Monoid[Box[Mul]]", monoidTests[Box[Mul]].monoid)
-    // FIXME: Doesn't work
-    //checkAll(s"$context.Monoid[Recursive]", monoidTests[Recursive].monoid)
+    checkAll(s"$context.Monoid[Recursive]", monoidTests[Recursive].monoid)
     checkAll(s"$context.Monoid is Serializable", SerializableTests.serializable(summonInline[Monoid[Foo]]))
     test(s"$context.Monoid respects existing instances") {
       val box = summonInline[Monoid[Box[Mul]]]

--- a/core/src/test/scala-3/cats/derived/SemigroupSuite.scala
+++ b/core/src/test/scala-3/cats/derived/SemigroupSuite.scala
@@ -33,8 +33,7 @@ class SemigroupSuite extends KittensSuite:
     checkAll(s"$context.Semigroup[Foo]", semigroupTests[Foo].semigroup)
     checkAll(s"$context.Semigroup[Interleaved[Int]]", semigroupTests[Interleaved[Int]].semigroup)
     checkAll(s"$context.Semigroup[Box[Mul]]", semigroupTests[Box[Mul]].semigroup)
-    // FIXME: Doesn't work
-    //checkAll(s"$context.Semigroup[Recursive]", semigroupTests[Recursive].semigroup)
+    checkAll(s"$context.Semigroup[Recursive]", semigroupTests[Recursive].semigroup)
     checkAll(s"$context.Semigroup is Serializable", SerializableTests.serializable(summonInline[Semigroup[Foo]]))
     test(s"$context.Semigroup respects existing instances") {
       val box = summonInline[Semigroup[Box[Mul]]]


### PR DESCRIPTION
Fix semigroup hierarchy derivation for recursive types