### PR TITLE
Require Or instances for givens

### DIFF
--- a/core/src/main/scala-3/cats/derived/DerivedEmptyK.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedEmptyK.scala
@@ -30,9 +30,9 @@ object DerivedEmptyK:
     new EmptyK[[x] =>> F[G[x]]]:
       def empty[A] = F.unify.empty
 
-  given [F[_], G[_]](using NotGiven[Or[F]])(using F: Pure[F], G: Or[G]): DerivedEmptyK[[x] =>> F[G[x]]] =
+  given [F[_], G[_]](using NotGiven[Or[F]])(using F: DerivedPure.Or[F], G: Or[G]): DerivedEmptyK[[x] =>> F[G[x]]] =
     new EmptyK[[x] =>> F[G[x]]]:
-      def empty[A] = F.pure(G.unify.empty)
+      def empty[A] = F.unify.pure(G.unify.empty)
 
   given product[F[_]](using inst: K1.ProductInstances[Or, F]): DerivedEmptyK[F] =
     new EmptyK[F]:

--- a/core/src/main/scala-3/cats/derived/DerivedFunctor.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedFunctor.scala
@@ -26,8 +26,12 @@ object DerivedFunctor:
   given [F[_], G[_]](using F: Or[F], G: Or[G]): DerivedFunctor[[x] =>> F[G[x]]] =
     F.unify.compose(G.unify)
 
-  given [F[_], G[_]](using F: Contravariant[F], G: Contravariant[G]): DerivedFunctor[[x] =>> F[G[x]]] =
-    F.compose(G)
+  given [F[_], G[_]](using
+      F: DerivedContravariant.Or[F],
+      G: DerivedContravariant.Or[G]
+  ): DerivedFunctor[[x] =>> F[G[x]]] =
+    given Contravariant[G] = G.unify
+    F.unify.compose[G]
 
   given [F[_]](using inst: => K1.Instances[Or, F]): DerivedFunctor[F] =
     given K1.Instances[Functor, F] = inst.unify


### PR DESCRIPTION
Resolves https://github.com/typelevel/kittens/issues/477.

However, this feature doesn't really seem to work as hoped (possibly related to https://github.com/typelevel/kittens/issues/473).

```scala
  case class In[A](value: A => Unit) derives Contravariant
  case class Out[A](value: A => Unit) derives Contravariant
  case class N[A](value: In[Out[A]]) derives Functor
```

works fine. But

```scala
  case class In[A](value: A => Unit)
  case class Out[A](value: A => Unit)
  case class N[A](value: In[Out[A]]) derives Functor
```

does not