### PR TITLE
Rewrite sequence, traverse and replicateH

### DIFF
--- a/core/src/main/scala-2/cats/replicateH/replicateH.scala
+++ b/core/src/main/scala-2/cats/replicateH/replicateH.scala
@@ -1,35 +1,46 @@
 package cats.replicateH
 
+import cats.Parallel
 import cats.sequence.Sequencer
 import shapeless._
 import shapeless.ops.hlist._
 
 sealed trait ReplicateH[F[_], N, A] extends Serializable {
-  type LOut
+  type LOut <: HList
   type Out = F[LOut]
   def apply(fa: F[A]): Out
+  def parApply(fa: F[A])(implicit par: Parallel[F]): Out
 }
 
 object ReplicateH {
-  type Aux[F[_], N, A, LOut0] = ReplicateH[F, N, A] { type LOut = LOut0 }
+  type Aux[F[_], N, A, O <: HList] = ReplicateH[F, N, A] {
+    type LOut = O
+  }
 
-  implicit def mkReplicater[F[_], N, A, LIn <: HList, LOut <: HList](implicit
-      filler: Fill.Aux[N, F[A], LIn],
-      sequencer: Sequencer.Aux[LIn, F, LOut]
-  ): Aux[F, N, A, LOut] =
-    new ReplicateH[F, N, A] {
-      type LOut = sequencer.LOut
-      def apply(fa: F[A]): Out = sequencer(filler(fa))
-    }
+  implicit def fromSequencer[F[_], N, A, L <: HList, O <: HList](implicit
+      fill: Fill.Aux[N, F[A], L],
+      seq: Sequencer.Aux[F, L, O]
+  ): Aux[F, N, A, O] = new ReplicateH[F, N, A] {
+    type LOut = O
+    def apply(fa: F[A]) = seq(fill(fa))
+    def parApply(fa: F[A])(implicit par: Parallel[F]) = seq.parApply(fill(fa))
+  }
 }
 
-trait ReplicateHFunctions {
-  def replicateH[F[_], A](n: Nat, fa: F[A])(implicit replicater: ReplicateH[F, n.N, A]): replicater.Out = replicater(fa)
-
+trait ReplicateHOps {
+  implicit def replicateHSyntax[F[_], A](fa: F[A]): ReplicateHOps.Syntax[F, A] =
+    new ReplicateHOps.Syntax(fa)
 }
 
-trait ReplicateHOps extends {
-  implicit class withReplicateH[F[_], A](self: F[A]) {
-    def replicateH(n: Nat)(implicit replicater: ReplicateH[F, n.N, A]): replicater.Out = replicater(self)
+object ReplicateHOps {
+  class Syntax[F[_], A](private val self: F[A]) extends AnyVal {
+    def replicateH(n: Nat)(implicit
+        rep: ReplicateH[F, n.N, A]
+    ): rep.Out = rep(self)
+
+    def parReplicateH(n: Nat)(implicit
+        rep: ReplicateH[F, n.N, A],
+        par: Parallel[F]
+    ): rep.Out = rep.parApply(self)
   }
 }

--- a/core/src/main/scala-2/cats/sequence/traverse.scala
+++ b/core/src/main/scala-2/cats/sequence/traverse.scala
@@ -12,59 +12,61 @@ import shapeless.ops.hlist._
 sealed trait Traverser[F[_], L <: HList, P] extends Serializable {
   type LOut <: HList
   type Out = F[LOut]
+
   def apply(hl: L): Out
-
-  // Defined sequentially for binary compatibility, overridden by implementations.
-  protected[sequence] def par(hl: L)(implicit P: Parallel[F]): P.F[LOut] =
-    P.parallel(apply(hl))
-
-  final def parApply(hl: L)(implicit P: Parallel[F]): Out =
-    P.sequential(par(hl)(P))
+  def parApply(hl: L)(implicit par: Parallel[F]): Out
 }
 
-sealed abstract private[sequence] class MkTraverser {
+sealed abstract private[sequence] class TraverserFromSequencer {
   type Aux[F[_], L <: HList, P, O <: HList] = Traverser[F, L, P] {
     type LOut = O
   }
 
-  implicit def mkTraverser[L <: HList, P, S <: HList](implicit
-      mapper: Mapper.Aux[P, L, S],
-      sequencer: Sequencer[S]
-  ): Aux[sequencer.F, L, P, sequencer.LOut] = new Traverser[sequencer.F, L, P] {
-    type LOut = sequencer.LOut
-    def apply(hl: L) = sequencer(mapper(hl))
-    override def par(hl: L)(implicit P: Parallel[sequencer.F]) = sequencer.par(mapper(hl))(P)
+  implicit def fromSequencer[L <: HList, P, S <: HList](implicit
+      map: Mapper.Aux[P, L, S],
+      seq: Sequencer[S]
+  ): Aux[seq.F, L, P, seq.LOut] = new Traverser[seq.F, L, P] {
+    type LOut = seq.LOut
+    def apply(hl: L) = seq(map(hl))
+    def parApply(hl: L)(implicit par: Parallel[seq.F]) = seq.parApply(map(hl))
   }
 }
 
-object Traverser extends MkTraverser {
-  implicit def hnilTraverser[F[_], P](implicit
-      F: Applicative[F]
-  ): Aux[F, HNil, P, HNil] = new Traverser[F, HNil, P] {
-    type LOut = HNil
-    def apply(nil: HNil) = F.pure(nil)
-    override def par(nil: HNil)(implicit P: Parallel[F]) = P.applicative.pure(nil)
-  }
+object Traverser extends TraverserFromSequencer {
+  def apply[F[_], L <: HList, P](implicit trav: Traverser[F, L, P]): trav.type = trav
+
+  implicit def nil[F[_], P](implicit app: Applicative[F]): Aux[F, HNil, P, HNil] =
+    new Traverser[F, HNil, P] {
+      type LOut = HNil
+      def apply(hl: HNil) = app.pure(hl)
+      def parApply(hl: HNil)(implicit par: Parallel[F]) =
+        par.sequential(par.applicative.pure(hl))
+    }
 }
 
-trait TraverseFunctions {
-  def traverse[F[_], L <: HList](hl: L)(f: Poly)(implicit traverser: Traverser[F, L, f.type]): traverser.Out =
-    traverser(hl)
+trait TraverseOps {
+  implicit def traverseSyntax[L <: HList](hl: L): TraverseOps.Syntax[L] =
+    new TraverseOps.Syntax(hl)
+
+  def traverse[F[_], L <: HList](hl: L)(f: Poly)(implicit
+      trav: Traverser[F, L, f.type]
+  ): trav.Out = trav(hl)
 
   def parTraverse[F[_], L <: HList](hl: L)(f: Poly)(implicit
-      traverser: Traverser[F, L, f.type],
+      trav: Traverser[F, L, f.type],
       par: Parallel[F]
-  ): traverser.Out = traverser.parApply(hl)
+  ): trav.Out = trav.parApply(hl)
 }
 
-trait TraverseOps extends {
-  implicit class withTraverse[L <: HList](self: L) {
-    def traverse[F[_]](f: Poly)(implicit traverser: Traverser[F, L, f.type]): traverser.Out =
-      traverser(self)
+object TraverseOps {
+  class Syntax[L <: HList](private val self: L) extends AnyVal {
+    def traverse[F[_]](f: Poly)(implicit
+        trav: Traverser[F, L, f.type]
+    ): trav.Out = trav(self)
 
     def parTraverse[F[_]](f: Poly)(implicit
-        traverser: Traverser[F, L, f.type],
+        trav: Traverser[F, L, f.type],
         par: Parallel[F]
-    ): traverser.Out = traverser.parApply(self)
+    ): trav.Out = trav.parApply(self)
   }
 }

--- a/core/src/main/scala-2/cats/sequence/traverse.scala
+++ b/core/src/main/scala-2/cats/sequence/traverse.scala
@@ -28,7 +28,7 @@ sealed abstract private[sequence] class TraverserFromSequencer {
   ): Aux[seq.F, L, P, seq.LOut] = new Traverser[seq.F, L, P] {
     type LOut = seq.LOut
     def apply(hl: L) = seq(map(hl))
-    def parApply(hl: L)(implicit par: Parallel[seq.F]) = seq.parApply(map(hl))
+    def parApply(hl: L)(implicit par: Parallel[seq.F]) = seq.parApply(map(hl))(par)
   }
 }
 

--- a/core/src/test/scala-2/cats/replicateH/ReplicateHSuite.scala
+++ b/core/src/test/scala-2/cats/replicateH/ReplicateHSuite.scala
@@ -9,52 +9,53 @@ import shapeless._
 class ReplicateHSuite extends KittensSuite {
   val getAndInc: State[Int, Int] = State(i => (i + 1, i))
 
-  property("replicating state example") {
-    val getAndInc5: State[Int, Int :: Int :: Int :: Int :: Int :: HNil] = getAndInc.replicateH(5)
-    getAndInc5.run(0).value ?= (5, 0 :: 1 :: 2 :: 3 :: 4 :: HNil)
+  test("replicating state example") {
+    val replicated: State[Int, Int :: Int :: Int :: Int :: Int :: HNil] = getAndInc.replicateH(5)
+    assertEquals(replicated.run(0).value, (5, 0 :: 1 :: 2 :: 3 :: 4 :: HNil))
   }
 
   property("replicating arbitrary state") {
     forAll { (initial: Int, x: State[Int, String]) =>
-      val expected: State[Int, List[String]] = x.replicateA(3)
       val replicated: State[Int, String :: String :: String :: HNil] = x.replicateH(3)
-      replicated.map(_.toList).run(initial).value ?= expected.run(initial).value
+      replicated.map(_.toList).run(initial).value ?= x.replicateA(3).run(initial).value
     }
   }
 
   property("replicating arbitrary lists") {
     forAll { (l: List[Long]) =>
-      val expected = l.replicateA(3)
-      val replicated = l.replicateH(3)
-      replicated.map(_.toList) ?= expected
+      val replicated: List[Long :: Long :: Long :: HNil] = l.replicateH(3)
+      replicated.map(_.toList) ?= l.replicateA(3)
     }
   }
 
   property("replicate 0 list") {
     forAll { (l: List[Long]) =>
-      val replicated = l.replicateH(0)
+      val replicated: List[HNil] = l.replicateH(0)
       replicated.map(_.toList) ?= List(Nil)
     }
   }
 
   property("replicate 1 list") {
     forAll { (l: List[Long]) =>
-      val replicated = l.replicateH(1)
+      val replicated: List[Long :: HNil] = l.replicateH(1)
       replicated.map(_.toList) ?= l.map(List(_))
     }
   }
 
   property("replicate 0 state") {
-    val getAndInc0: State[Int, HNil] = getAndInc.replicateH(0)
-    forAll { (initial: Int) =>
-      getAndInc0.run(initial).value ?= (initial, HNil)
-    }
+    val replicated: State[Int, HNil] = getAndInc.replicateH(0)
+    forAll((initial: Int) => replicated.run(initial).value ?= (initial, HNil))
   }
 
   property("replicate 1 state") {
-    val getAndInc1: State[Int, Int :: HNil] = getAndInc.replicateH(1)
-    forAll { (initial: Int) =>
-      getAndInc1.run(initial).value ?= (initial + 1, initial :: HNil)
+    val replicated: State[Int, Int :: HNil] = getAndInc.replicateH(1)
+    forAll((initial: Int) => replicated.run(initial).value ?= (initial + 1, initial :: HNil))
+  }
+
+  property("parReplicate Either") {
+    forAll { (e: Either[Int, String]) =>
+      val replicated: Either[Int, String :: String :: String :: HNil] = e.parReplicateH(3)
+      replicated.map(_.toList) ?= e.parReplicateA(3)
     }
   }
 }

--- a/core/src/test/scala-2/cats/sequence/SequenceSuite.scala
+++ b/core/src/test/scala-2/cats/sequence/SequenceSuite.scala
@@ -11,212 +11,280 @@ import cats.laws.discipline.arbitrary._
 import org.scalacheck.Prop.forAll
 import shapeless._
 import shapeless.record.Record
-import shapeless.syntax.singleton._
+
+import scala.annotation.nowarn
 
 class SequenceSuite extends KittensSuite {
+  import SequenceSuite._
+
+  type ShortErr[A] = Either[Int, A]
+  type AccumErr[A] = Validated[Int, A]
+
+  test("sequencing HNil") {
+    val nil: HNil = HNil
+    assert(nil.sequence[Option].contains(HNil))
+    @nowarn("cat=deprecation")
+    val stream = nil.parSequence[Stream]
+    assertEquals(stream(42), HNil)
+  }
 
   property("sequencing Option") {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
       val expected = (x, y, z).mapN(_ :: _ :: _ :: HNil)
-      (x :: y :: z :: HNil).sequence == expected
+      sequence(x, y, z) == expected && (x :: y :: z :: HNil).sequence == expected
     }
   }
 
-  property("sequencing HNil with Option") {
-    // We can't simply use HNil.sequence, because F would be ambiguous.
-    // However, we can explicitly grab the Sequencer for Option and use it.
-    implicitly[Sequencer.Aux[HNil, Option, HNil]].apply(HNil) contains HNil
-  }
-
   property("sequencing Either") {
-    forAll { (x: Either[String, Int], y: Either[String, String], z: Either[String, Float]) =>
+    forAll { (x: ShortErr[Int], y: ShortErr[String], z: ShortErr[Float]) =>
       val expected = (x, y, z).mapN(_ :: _ :: _ :: HNil)
-      (x :: y :: z :: HNil).sequence == expected
+      sequence(x, y, z) == expected && (x :: y :: z :: HNil).sequence == expected
     }
   }
 
   property("parallel sequencing Either") {
-    forAll { (x: Either[String, Int], y: Either[String, String], z: Either[String, Float]) =>
-      val expected = (
-        Validated.fromEither(x),
-        Validated.fromEither(y),
-        Validated.fromEither(z)
-      ).mapN(_ :: _ :: _ :: HNil).toEither
-      (x :: y :: z :: HNil).parSequence == expected
+    forAll { (x: ShortErr[Int], y: ShortErr[String], z: ShortErr[Float]) =>
+      val expected = (x, y, z).parMapN(_ :: _ :: _ :: HNil)
+      parSequence(x, y, z) == expected && (x :: y :: z :: HNil).parSequence == expected
     }
   }
 
-  // note: using the ValidationNel type alias here breaks the implicit search
-  property("sequencing ValidatedNel") {
-    forAll {
-      (
-          x: Validated[NonEmptyList[String], Int],
-          y: Validated[NonEmptyList[String], String],
-          z: Validated[NonEmptyList[String], Float]
-      ) =>
-        val expected = (x, y, z).mapN(_ :: _ :: _ :: HNil)
-        sequence(x, y, z) == expected
+  property("parallel sequencing Stream") {
+    @nowarn("cat=deprecation")
+    val prop = forAll { (x: Stream[Int], y: Stream[String], z: Stream[Float]) =>
+      val expected = (x, y, z).parMapN(_ :: _ :: _ :: HNil)
+      parSequence(x, y, z) == expected && (x :: y :: z :: HNil).parSequence == expected
+    }
+
+    prop
+  }
+
+  property("sequencing Validated") {
+    forAll { (x: AccumErr[Int], y: AccumErr[String], z: AccumErr[Float]) =>
+      val expected = (x, y, z).mapN(_ :: _ :: _ :: HNil)
+      sequence(x, y, z) == expected && (x :: y :: z :: HNil).sequence == expected
     }
   }
 
   test("sequencing Function") {
-    val f1 = (_: String).length
-    val f2 = (_: String).reverse
-    val f3 = (_: String).toDouble
-    val f = (f1 :: f2 :: f3 :: HNil).sequence
-    assert(f("42.0") == 4 :: "0.24" :: 42.0 :: HNil)
+    val x = (_: String).length
+    val y = (_: String).reverse
+    val z = (_: String).toFloat
+    val f = sequence(x, y, z)
+    val g = (x :: y :: z :: HNil).sequence
+    val expected = 4 :: "0.24" :: 42.0 :: HNil
+    assert(f("42.0") == expected)
+    assert(g("42.0") == expected)
   }
 
   property("sequencing Semigroup") {
-    val si = Semigroup[Int]
-    val ss = Semigroup[String]
-    val sis = (si :: ss :: HNil).sequence
-    forAll { (i1: Int, s1: String, i2: Int, s2: String) =>
-      sis.combine(i1 :: s1 :: HNil, i2 :: s2 :: HNil) == si.combine(i1, i2) :: ss.combine(s1, s2) :: HNil
+    val sg1 = sequence(Semigroup[Int], Semigroup[String], Semigroup[Float])
+    val sg2 = (Semigroup[Int] :: Semigroup[String] :: Semigroup[Float] :: HNil).sequence
+    forAll { (i1: Int, s1: String, f1: Float, i2: Int, s2: String, f2: Float) =>
+      val x = i1 :: s1 :: f1 :: HNil
+      val y = i2 :: s2 :: f2 :: HNil
+      val expected = (i1 + i2) :: (s1 + s2) :: (f1 + f2) :: HNil
+      sg1.combine(x, y) == expected && sg2.combine(x, y) == expected
     }
   }
 
-  test("sequencing Function using ProductArgs") {
-    val f1 = (_: String).length
-    val f2 = (_: String).reverse
-    val f3 = (_: String).toDouble
-    val f = sequence(f1, f2, f3)
-    assert(f("42.0") == 4 :: "0.24" :: 42.0 :: HNil)
-  }
-
-  test("sequencing Klesilis through ProductArgs") {
-    val f1 = ((_: String).length).andThen(Option.apply)
-    val f2 = ((_: String).reverse).andThen(Option.apply)
-    val f3 = ((_: String).toDouble).andThen(Option.apply)
-    val f = sequence(Kleisli(f1), Kleisli(f2), Kleisli(f3))
-    val expected = Some((Symbol("a") ->> 4) :: (Symbol("b") ->> "0.24") :: (Symbol("c") ->> 42.0) :: HNil)
-    assert(f.run("42.0") == expected)
+  test("sequencing Kleisli") {
+    val x = ((_: String).length).andThen(Option.apply)
+    val y = ((_: String).reverse).andThen(Option.apply)
+    val z = ((_: String).toFloat).andThen(Option.apply)
+    val f = sequence(Kleisli(x), Kleisli(y), Kleisli(z))
+    val g = (Kleisli(x) :: Kleisli(y) :: Kleisli(z) :: HNil).sequence
+    val expected = Some(4 :: "0.24" :: 42.0 :: HNil)
+    assert(f("42.0") == expected)
+    assert(g("42.0") == expected)
   }
 
   property("sequencing record of Option") {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val expected = for {
-        a <- x
-        b <- y
-        c <- z
-      } yield ("a" ->> a) :: ("b" ->> b) :: ("c" ->> c) :: HNil
-      (("a" ->> x) :: ("b" ->> y) :: ("c" ->> z) :: HNil).sequence == expected
-    }
-  }
-
-  property("sequencing record of Option using RecordArgs") {
-    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val expected = for {
-        a <- x
-        b <- y
-        c <- z
-      } yield ("a" ->> a) :: ("b" ->> b) :: ("c" ->> c) :: HNil
-      sequenceRecord(a = x, b = y, c = z) == expected
+      val expected = (x, y, z).mapN((a, b, c) => Record(a = a, b = b, c = c))
+      sequenceNamed(a = x, b = y, c = z) == expected &&
+      Record(a = x, b = y, c = z).sequence == expected
     }
   }
 
   property("sequencing record of Either") {
-    forAll { (x: Either[String, Int], y: Either[String, String], z: Either[String, Float]) =>
-      val expected = for {
-        a <- x
-        b <- y
-        c <- z
-      } yield ("a" ->> a) :: ("b" ->> b) :: ("c" ->> c) :: HNil
-      (("a" ->> x) :: ("b" ->> y) :: ("c" ->> z) :: HNil).sequence == expected
+    forAll { (x: ShortErr[Int], y: ShortErr[String], z: ShortErr[Float]) =>
+      val expected = (x, y, z).mapN((a, b, c) => Record(a = a, b = b, c = c))
+      sequenceNamed(a = x, b = y, c = z) == expected &&
+      Record(a = x, b = y, c = z).sequence == expected
     }
   }
 
-  test("sequencing record of Functions through RecordArgs") {
-    val f1 = (_: String).length
-    val f2 = (_: String).reverse
-    val f3 = (_: String).toDouble
-    val f = sequenceRecord(a = f1, b = f2, c = f3)
-    val expected = ("a" ->> 4) :: ("b" ->> "0.24") :: ("c" ->> 42.0) :: HNil
+  property("parallel sequencing record of Either") {
+    forAll { (x: ShortErr[Int], y: ShortErr[String], z: ShortErr[Float]) =>
+      val expected = (x, y, z).parMapN((a, b, c) => Record(a = a, b = b, c = c))
+      parSequenceNamed(a = x, b = y, c = z) == expected &&
+      Record(a = x, b = y, c = z).parSequence == expected
+    }
+  }
+
+  property("parallel sequencing record of Stream") {
+    @nowarn("cat=deprecation")
+    val prop = forAll { (x: Stream[Int], y: Stream[String], z: Stream[Float]) =>
+      val expected = (x, y, z).parMapN((a, b, c) => Record(a = a, b = b, c = c))
+      parSequenceNamed(a = x, b = y, c = z) == expected &&
+      Record(a = x, b = y, c = z).parSequence == expected
+    }
+
+    prop
+  }
+
+  property("sequencing record of Validated") {
+    forAll { (x: AccumErr[Int], y: AccumErr[String], z: AccumErr[Float]) =>
+      val expected = (x, y, z).mapN((a, b, c) => Record(a = a, b = b, c = c))
+      sequenceNamed(a = x, b = y, c = z) == expected &&
+      Record(a = x, b = y, c = z).sequence == expected
+    }
+  }
+
+  test("sequencing record of Function") {
+    val x = (_: String).length
+    val y = (_: String).reverse
+    val z = (_: String).toFloat
+    val f = sequenceNamed(a = x, b = y, c = z)
+    val g = Record(a = x, b = y, c = z).sequence
+    val expected = Record(a = 4, b = "0.24", c = 42.0)
     assert(f("42.0") == expected)
+    assert(g("42.0") == expected)
   }
 
-  test("sequencing record of Kleisli through RecordArgs") {
-    val f1 = ((_: String).length).andThen(Option.apply)
-    val f2 = ((_: String).reverse).andThen(Option.apply)
-    val f3 = ((_: String).toDouble).andThen(Option.apply)
-    val f = sequenceRecord(a = Kleisli(f1), b = Kleisli(f2), c = Kleisli(f3))
-    val expected = Some(("a" ->> 4) :: ("b" ->> "0.24") :: ("c" ->> 42.0) :: HNil)
-    assert(f.run("42.0") == expected)
+  test("sequencing record of Kleisli") {
+    val x = ((_: String).length).andThen(Option.apply)
+    val y = ((_: String).reverse).andThen(Option.apply)
+    val z = ((_: String).toFloat).andThen(Option.apply)
+    val f = sequenceNamed(a = Kleisli(x), b = Kleisli(y), c = Kleisli(z))
+    val g = Record(a = Kleisli(x), b = Kleisli(y), c = Kleisli(z)).sequence
+    val expected = Some(Record(a = 4, b = "0.24", c = 42.0))
+    assert(f("42.0") == expected)
+    assert(g("42.0") == expected)
   }
 
-  property("sequencing record of Semigroup through RecordArgs") {
-    val si = Semigroup[Int]
-    val ss = Semigroup[String]
-    val sis = sequenceRecord(i = si, s = ss)
-    forAll { (i1: Int, s1: String, i2: Int, s2: String) =>
-      val rec1 = Record(i = i1, s = s1)
-      val rec2 = Record(i = i2, s = s2)
-      sis.combine(rec1, rec2) == ("i" ->> si.combine(i1, i2)) :: ("s" ->> ss.combine(s1, s2)) :: HNil
-    }
-  }
-
-  case class MyCase(a: Int, b: String, c: Float)
-
-  property("sequence gen for Option") {
-    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val myGen = sequenceGeneric[MyCase]
-      val expected = (x, y, z).mapN(MyCase.apply)
-      myGen(a = x, b = y, c = z) == expected
-    }
-  }
-
-  property("sequence gen with different sort") {
-    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val myGen = sequenceGeneric[MyCase]
-      val expected = (x, y, z).mapN(MyCase.apply)
-      myGen(b = y, a = x, c = z) == expected
-    }
-  }
-
-  property("sequence gen for Either") {
-    forAll { (x: Either[String, Int], y: Either[String, String], z: Either[String, Float]) =>
-      val myGen = sequenceGeneric[MyCase]
-      val expected = (x, y, z).mapN(MyCase.apply)
-      myGen(a = x, b = y, c = z) == expected
-    }
-  }
-
-  test("sequence gen for Functions") {
-    val f1 = (_: String).length
-    val f2 = (_: String).reverse
-    val f3 = (_: String).toFloat
-    val myGen = sequenceGeneric[MyCase]
-    val f = myGen(a = f1, b = f2, c = f3)
-    assert(f("42.0") == MyCase(4, "0.24", 42.0f))
-  }
-
-  test("sequence gen for Klesili") {
-    val f1 = ((_: String).length).andThen(Option.apply)
-    val f2 = ((_: String).reverse).andThen(Option.apply)
-    val f3 = ((_: String).toFloat).andThen(Option.apply)
-    val myGen = sequenceGeneric[MyCase]
-    val f = myGen(a = Kleisli(f1), b = Kleisli(f2), c = Kleisli(f3))
-    assert(f.run("42.0") == Some(MyCase(4, "0.24", 42.0f)))
-  }
-
-  property("sequencing gen for Semigroup") {
-    val si = Semigroup[Int]
-    val ss = Semigroup[String]
-    val sf = Semigroup[Float]
-    val myGen = sequenceGeneric[MyCase]
-    val sm = myGen(a = si, b = ss, c = sf)
+  property("sequencing record of Semigroup") {
+    val sg1 = sequenceNamed(i = Semigroup[Int], s = Semigroup[String], f = Semigroup[Float])
+    val sg2 = Record(i = Semigroup[Int], s = Semigroup[String], f = Semigroup[Float]).sequence
     forAll { (i1: Int, s1: String, f1: Float, i2: Int, s2: String, f2: Float) =>
-      sm.combine(MyCase(i1, s1, f1), MyCase(i2, s2, f2)) == MyCase(
-        si.combine(i1, i2),
-        ss.combine(s1, s2),
-        sf.combine(f1, f2)
-      )
+      val x = Record(i = i1, s = s1, f = f1)
+      val y = Record(i = i2, s = s2, f = f2)
+      val expected = Record(i = i1 + i2, s = s1 + s2, f = f1 + f2)
+      sg1.combine(x, y) == expected && sg2.combine(x, y) == expected
     }
   }
 
-  checkAll("RecordSequencer is Serializable", SerializableTests.serializable(SequenceSuite.recordSequencer))
+  property("sequencing to case class of Option") {
+    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
+      val expected = (x, y, z).mapN(MyCase)
+      sequenceTo[MyCase].apply(x, y, z) == expected &&
+      sequenceTo[MyCase].named(a = x, b = y, c = z) == expected &&
+      (x :: y :: z :: HNil).sequenceTo[MyCase] == expected &&
+      Record(a = x, b = y, c = z).sequenceTo[MyCase] == expected
+    }
+  }
+
+  property("sequencing to case class in different order") {
+    forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
+      val expected = (x, y, z).mapN(MyCase)
+      sequenceTo[MyCase].named(b = y, a = x, c = z) == expected &&
+      Record(b = y, a = x, c = z).sequenceTo[MyCase] == expected
+    }
+  }
+
+  property("sequencing to case class of Either") {
+    forAll { (x: ShortErr[Int], y: ShortErr[String], z: ShortErr[Float]) =>
+      val expected = (x, y, z).mapN(MyCase)
+      sequenceTo[MyCase].apply(x, y, z) == expected &&
+      sequenceTo[MyCase].named(a = x, b = y, c = z) == expected &&
+      (x :: y :: z :: HNil).sequenceTo[MyCase] == expected &&
+      Record(a = x, b = y, c = z).sequenceTo[MyCase] == expected
+    }
+  }
+
+  property("parallel sequencing to case class of Either") {
+    forAll { (x: ShortErr[Int], y: ShortErr[String], z: ShortErr[Float]) =>
+      val expected = (x, y, z).parMapN(MyCase)
+      sequenceTo[MyCase].par(x, y, z) == expected &&
+      sequenceTo[MyCase].parNamed(a = x, b = y, c = z) == expected &&
+      (x :: y :: z :: HNil).parSequenceTo[ShortErr, MyCase] == expected &&
+      Record(a = x, b = y, c = z).parSequenceTo[ShortErr, MyCase] == expected
+    }
+  }
+
+  property("parallel sequencing to case class of Stream") {
+    @nowarn("cat=deprecation")
+    val prop = forAll { (x: Stream[Int], y: Stream[String], z: Stream[Float]) =>
+      val expected = (x, y, z).parMapN(MyCase)
+      sequenceTo[MyCase].par(x, y, z) == expected &&
+      sequenceTo[MyCase].parNamed(a = x, b = y, c = z) == expected &&
+      (x :: y :: z :: HNil).parSequenceTo[Stream, MyCase] == expected &&
+      Record(a = x, b = y, c = z).parSequenceTo[Stream, MyCase] == expected
+    }
+
+    prop
+  }
+
+  property("sequencing to case class of Validated") {
+    forAll { (x: AccumErr[Int], y: AccumErr[String], z: AccumErr[Float]) =>
+      val expected = (x, y, z).mapN(MyCase)
+      sequenceTo[MyCase].apply(x, y, z) == expected &&
+      sequenceTo[MyCase].named(a = x, b = y, c = z) == expected &&
+      (x :: y :: z :: HNil).sequenceTo[MyCase] == expected &&
+      Record(a = x, b = y, c = z).sequenceTo[MyCase] == expected
+    }
+  }
+
+  test("sequencing to case class of Function") {
+    val x = (_: String).length
+    val y = (_: String).reverse
+    val z = (_: String).toFloat
+    val f = sequenceTo[MyCase].apply(x, y, z)
+    val g = sequenceTo[MyCase].named(a = x, b = y, c = z)
+    val h = (x :: y :: z :: HNil).sequenceTo[MyCase]
+    val i = Record(a = x, b = y, c = z).sequenceTo[MyCase]
+    val expected = MyCase(4, "0.24", 42.0f)
+    assert(f("42.0") == expected)
+    assert(g("42.0") == expected)
+    assert(h("42.0") == expected)
+    assert(i("42.0") == expected)
+  }
+
+  test("sequencing to case class of Klesili") {
+    val x = ((_: String).length).andThen(Option.apply)
+    val y = ((_: String).reverse).andThen(Option.apply)
+    val z = ((_: String).toFloat).andThen(Option.apply)
+    val f = sequenceTo[MyCase].apply(Kleisli(x), Kleisli(y), Kleisli(z))
+    val g = sequenceTo[MyCase].named(a = Kleisli(x), b = Kleisli(y), c = Kleisli(z))
+    val h = (Kleisli(x) :: Kleisli(y) :: Kleisli(z) :: HNil).sequenceTo[MyCase]
+    val i = Record(a = Kleisli(x), b = Kleisli(y), c = Kleisli(z)).sequenceTo[MyCase]
+    val expected = Some(MyCase(4, "0.24", 42.0f))
+    assert(f("42.0") == expected)
+    assert(g("42.0") == expected)
+    assert(h("42.0") == expected)
+    assert(i("42.0") == expected)
+  }
+
+  property("sequencing to case class of Semigroup") {
+    val sg1 = sequenceTo[MyCase].apply(Semigroup[Int], Semigroup[String], Semigroup[Float])
+    val sg2 = sequenceTo[MyCase].named(a = Semigroup[Int], b = Semigroup[String], c = Semigroup[Float])
+    val sg3 = (Semigroup[Int] :: Semigroup[String] :: Semigroup[Float] :: HNil).sequenceTo[MyCase]
+    val sg4 = Record(a = Semigroup[Int], b = Semigroup[String], c = Semigroup[Float]).sequenceTo[MyCase]
+    forAll { (i1: Int, s1: String, f1: Float, i2: Int, s2: String, f2: Float) =>
+      val x = MyCase(i1, s1, f1)
+      val y = MyCase(i2, s2, f2)
+      val expected = MyCase(i1 + i2, s1 + s2, f1 + f2)
+      sg1.combine(x, y) == expected && sg2.combine(x, y) == expected &&
+      sg3.combine(x, y) == expected && sg4.combine(x, y) == expected
+    }
+  }
+
+  checkAll("Sequencer is Serializable", SerializableTests.serializable(Sequencer[MyCaseOpt]))
+  checkAll("GenericSequencer is Serializable", SerializableTests.serializable(GenericSequencer[MyCase, MyCaseOpt]))
 }
 
 object SequenceSuite {
-  val recordSequencer = the[RecordSequencer[Record.`"a" -> Option[Int], "b" -> Option[String]`.T]]
+  final case class MyCase(a: Int, b: String, c: Float)
+  type MyCaseOpt = Option[Int] :: Option[String] :: Option[Float] :: HNil
 }

--- a/core/src/test/scala-2/cats/sequence/SequenceSuite.scala
+++ b/core/src/test/scala-2/cats/sequence/SequenceSuite.scala
@@ -20,11 +20,12 @@ class SequenceSuite extends KittensSuite {
   type ShortErr[A] = Either[Int, A]
   type AccumErr[A] = Validated[Int, A]
 
+  // We can't simply use HNil.sequence, because F would be ambiguous.
+  // However, we can explicitly grab the Sequencer for Option and use it.
   test("sequencing HNil") {
-    val nil: HNil = HNil
-    assert(nil.sequence[Option].contains(HNil))
+    assert(implicitly[Sequencer.Aux[Option, HNil, HNil]].apply(HNil).contains(HNil))
     @nowarn("cat=deprecation")
-    val stream = nil.parSequence[Stream]
+    val stream = implicitly[Sequencer.Aux[Stream, HNil, HNil]].parApply(HNil)
     assertEquals(stream(42), HNil)
   }
 

--- a/core/src/test/scala-2/cats/sequence/TraverseSuite.scala
+++ b/core/src/test/scala-2/cats/sequence/TraverseSuite.scala
@@ -10,7 +10,10 @@ import shapeless._
 
 class TraverseSuite extends KittensSuite {
 
-  def optToValidation[T](opt: Option[T]): Validated[String, T] =
+  def o2e[T](opt: Option[T]): Either[String, T] =
+    opt.toRight("Nothing Here")
+
+  def o2v[T](opt: Option[T]): Validated[String, T] =
     Validated.fromOption(opt, "Nothing Here")
 
   object headOption extends Poly1 {
@@ -18,11 +21,11 @@ class TraverseSuite extends KittensSuite {
   }
 
   object optionToValidation extends Poly1 {
-    implicit def caseOption[T] = at[Option[T]](optToValidation)
+    implicit def caseOption[T] = at(o2v[T])
   }
 
   object optionToEither extends Poly1 {
-    implicit def caseOption[T] = at[Option[T]](_.toRight("Nothing Here"))
+    implicit def caseOption[T] = at(o2e[T])
   }
 
   property("traversing Set with Set => Option") {
@@ -34,18 +37,14 @@ class TraverseSuite extends KittensSuite {
 
   property("traversing Option with Option => Validation") {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val expected = (optToValidation(x), optToValidation(y), optToValidation(z)).mapN(_ :: _ :: _ :: HNil)
+      val expected = (o2v(x), o2v(y), o2v(z)).mapN(_ :: _ :: _ :: HNil)
       (x :: y :: z :: HNil).traverse(optionToValidation) == expected
     }
   }
 
   property("parallel traversing Option with Option => Either") {
     forAll { (x: Option[Int], y: Option[String], z: Option[Float]) =>
-      val expected = (
-        optToValidation(x),
-        optToValidation(y),
-        optToValidation(z)
-      ).mapN(_ :: _ :: _ :: HNil).toEither
+      val expected = (o2e(x), o2e(y), o2e(z)).parMapN(_ :: _ :: _ :: HNil)
       (x :: y :: z :: HNil).parTraverse(optionToEither) == expected
     }
   }


### PR DESCRIPTION
 - Remove binary compatibility artifacts
 - Properly support parallel versions in all cases
 - Simplify which improves compilation times
 - Support generic sequence without records

Fixes #423