### PR TITLE
Refactor Derived.Or type aliases

### DIFF
--- a/core/src/main/scala-3/cats/derived/Derived.scala
+++ b/core/src/main/scala-3/cats/derived/Derived.scala
@@ -1,19 +1,23 @@
 package cats.derived
 
 import shapeless3.deriving.*
+import shapeless3.deriving.internals.ErasedInstances
 
 import scala.annotation.*
 import scala.compiletime.summonFrom
+
+private[derived] infix type >>>[F[_], G[_]] = [x] =>> G[F[x]]
+private[derived] infix type <<<[F[_], G[_]] = [x] =>> F[G[x]]
+
+private[derived] given [I[k, t] <: ErasedInstances[k, t], K, T](using inst: I[K, Derived.Or[T]]): I[K, T] =
+  Derived.Or.unify(inst)
 
 @implicitNotFound("Could not derive an instance of ${A}")
 opaque type Derived[A] = A
 object Derived:
   def apply[A](instance: A): Derived[A] = instance
+  given [A]: Conversion[A, Derived[A]] = identity
   extension [A](derived: Derived[A]) def instance: A = derived
-  given [A]: Conversion[A, Derived[A]] = apply
-
-  infix type >>>[F[_], G[_]] = [x] =>> G[F[x]]
-  infix type <<<[F[_], G[_]] = [x] =>> F[G[x]]
 
   type Or0[F[_]] = [x] =>> Derived.Or[F[x]]
   type Or1[F[_[_]]] = [x[_]] =>> Derived.Or[F[x]]
@@ -23,15 +27,30 @@ object Derived:
   opaque type Or[A] = A
   object Or extends OrInstances:
     def apply[A](instance: A): Or[A] = instance
+    given [A]: Conversion[Or[A], A] = identity
     extension [A](derived: Or[A]) def unify: A = derived
-    extension [I[f[_], t] <: K0.Instances[f, t], F[_], T](inst: I[Or0[F], T])
-      @targetName("unifyK0") def unify: I[F, T] = inst
-    extension [I[f[_[_]], t[_]] <: K1.Instances[f, t], F[_[_]], T[_]](inst: I[Or1[F], T])
-      @targetName("unifyK1") def unify: I[F, T] = inst
-    extension [I[f[_[_[_]]], t[_[_]]] <: K11.Instances[f, t], F[_[_[_]]], T[_[_]]](inst: I[Or11[F], T])
-      @targetName("unifyK11") def unify: I[F, T] = inst
-    extension [I[f[_[_, _]], t[_, _]] <: K2.Instances[f, t], F[_[_, _]], T[_, _]](inst: I[Or2[F], T])
-      @targetName("unifyK2") def unify: I[F, T] = inst
+    extension [I[k, t] <: ErasedInstances[k, t], K, T](inst: I[K, Or[T]])
+      @targetName("unifyInstances") def unify: I[K, T] = inst
+
+    @deprecated("Use unifyInstances instead")
+    def unifyK0[I[f[_], t] <: K0.Instances[f, t], F[_], T](
+        inst: I[Or0[F], T]
+    ): I[F, T] = inst
+
+    @deprecated("Use unifyInstances instead")
+    def unifyK1[I[f[_[_]], t[_]] <: K1.Instances[f, t], F[_[_]], T[_]](
+        inst: I[Or1[F], T]
+    ): I[F, T] = inst
+
+    @deprecated("Use unifyInstances instead")
+    def unifyK11[I[f[_[_[_]]], t[_[_]]] <: K11.Instances[f, t], F[_[_[_]]], T[_[_]]](
+        inst: I[Or11[F], T]
+    ): I[F, T] = inst
+
+    @deprecated("Use unifyInstances instead")
+    def unifyK2[I[f[_[_, _]], t[_, _]] <: K2.Instances[f, t], F[_[_, _]], T[_, _]](
+        inst: I[Or2[F], T]
+    ): I[F, T] = inst
 
   private[derived] open class Lazy[A](f: () => A) extends Serializable:
     final protected lazy val delegate: A = f()

--- a/core/src/main/scala-3/cats/derived/DerivedAlternative.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedAlternative.scala
@@ -1,7 +1,6 @@
 package cats.derived
 
 import cats.Alternative
-import cats.derived.Derived.<<<
 import shapeless3.deriving.K1.*
 
 import scala.annotation.*
@@ -13,8 +12,6 @@ Make sure it satisfies one of the following conditions:
   * generic case class where all fields form Alternative""")
 type DerivedAlternative[F[_]] = Derived[Alternative[F]]
 object DerivedAlternative:
-  type Or[F[_]] = Derived.Or[Alternative[F]]
-
   @nowarn("msg=unused import")
   inline def apply[F[_]]: Alternative[F] =
     import DerivedAlternative.given
@@ -26,14 +23,14 @@ object DerivedAlternative:
     summonInline[DerivedAlternative[F]].instance
 
   given nested[F[_], G[_]](using
-      F: => DerivedAlternative.Or[F],
-      G: => DerivedApplicative.Or[G]
+      F: => Derived.Or[Alternative[F]],
+      G: => Derived.Or[Alternative[G]]
   ): DerivedAlternative[F <<< G] =
-    new Derived.Lazy(() => F.unify.compose(using G.unify)) with Alternative[F <<< G]:
+    new Derived.Lazy(() => F.compose(using G)) with Alternative[F <<< G]:
       export delegate.*
 
-  given product[F[_]](using inst: => ProductInstances[Or, F]): DerivedAlternative[F] =
-    Strict.product(using inst.unify)
+  given product[F[_]](using inst: => ProductInstances[Derived.Or1[Alternative], F]): DerivedAlternative[F] =
+    Strict.product
 
   trait Product[T[f[_]] <: Alternative[f], F[_]: ProductInstancesOf[T]]
       extends Alternative[F],

--- a/core/src/main/scala-3/cats/derived/DerivedApplicative.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedApplicative.scala
@@ -1,6 +1,5 @@
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.{Applicative, Monoid}
 import shapeless3.deriving.Const
 import shapeless3.deriving.K1.*
@@ -15,8 +14,6 @@ Make sure it satisfies one of the following conditions:
   * generic case class where all fields form Applicative""")
 type DerivedApplicative[F[_]] = Derived[Applicative[F]]
 object DerivedApplicative:
-  type Or[F[_]] = Derived.Or[Applicative[F]]
-
   @nowarn("msg=unused import")
   inline def apply[F[_]]: Applicative[F] =
     import DerivedApplicative.given
@@ -32,18 +29,18 @@ object DerivedApplicative:
     def ap[A, B](ff: T)(fa: T): T = T.combine(ff, fa)
 
   given nested[F[_], G[_]](using
-      F: => DerivedApplicative.Or[F],
-      G: => DerivedApplicative.Or[G]
+      F: => Derived.Or[Applicative[F]],
+      G: => Derived.Or[Applicative[G]]
   ): DerivedApplicative[F <<< G] =
-    new Derived.Lazy(() => F.unify.compose(using G.unify)) with Applicative[F <<< G]:
+    new Derived.Lazy(() => F.compose(using G)) with Applicative[F <<< G]:
       export delegate.*
 
-  given [F[_]](using inst: => ProductInstances[Or, F]): DerivedApplicative[F] =
-    Strict.product(using inst.unify)
+  given [F[_]](using inst: => ProductInstances[Derived.Or1[Applicative], F]): DerivedApplicative[F] =
+    Strict.product
 
   @deprecated("Kept for binary compatibility", "3.2.0")
-  protected given [F[_]: DerivedApplicative.Or, G[_]: DerivedApplicative.Or]: DerivedApplicative[[x] =>> F[G[x]]] =
-    nested
+  protected given [F[_]: Derived.Or1[Applicative], G[_]: Derived.Or1[Applicative]]
+      : DerivedApplicative[[x] =>> F[G[x]]] = nested
 
   trait Product[T[f[_]] <: Applicative[f], F[_]](using inst: ProductInstances[T, F])
       extends Applicative[F],

--- a/core/src/main/scala-3/cats/derived/DerivedBand.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedBand.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form Band.""")
 type DerivedBand[A] = Derived[Band[A]]
 object DerivedBand:
-  type Or[A] = Derived.Or[Band[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Band[A] =
     import DerivedBand.given
@@ -22,8 +20,8 @@ object DerivedBand:
     import Strict.given
     summonInline[DerivedBand[A]].instance
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedBand[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[Band], A]): DerivedBand[A] =
+    Strict.product
 
   trait Product[F[x] <: Band[x], A: ProductInstancesOf[F]] extends DerivedSemigroup.Product[F, A], Band[A]
 

--- a/core/src/main/scala-3/cats/derived/DerivedBoundedSemilattice.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedBoundedSemilattice.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form BoundedSemilattice.""")
 type DerivedBoundedSemilattice[A] = Derived[BoundedSemilattice[A]]
 object DerivedBoundedSemilattice:
-  type Or[A] = Derived.Or[BoundedSemilattice[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: BoundedSemilattice[A] =
     import DerivedBoundedSemilattice.given
@@ -22,8 +20,8 @@ object DerivedBoundedSemilattice:
     import Strict.given
     summonInline[DerivedBoundedSemilattice[A]].instance
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedBoundedSemilattice[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[BoundedSemilattice], A]): DerivedBoundedSemilattice[A] =
+    Strict.product
 
   trait Product[F[x] <: BoundedSemilattice[x], A: ProductInstancesOf[F]]
       extends DerivedCommutativeMonoid.Product[F, A],

--- a/core/src/main/scala-3/cats/derived/DerivedCommutativeGroup.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedCommutativeGroup.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form CommutativeGroup.""")
 type DerivedCommutativeGroup[A] = Derived[CommutativeGroup[A]]
 object DerivedCommutativeGroup:
-  type Or[A] = Derived.Or[CommutativeGroup[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: CommutativeGroup[A] =
     import DerivedCommutativeGroup.given
@@ -22,8 +20,8 @@ object DerivedCommutativeGroup:
     import Strict.given
     summonInline[DerivedCommutativeGroup[A]].instance
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedCommutativeGroup[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[CommutativeGroup], A]): DerivedCommutativeGroup[A] =
+    Strict.product
 
   trait Product[F[x] <: CommutativeGroup[x], A: ProductInstancesOf[F]]
       extends DerivedGroup.Product[F, A],

--- a/core/src/main/scala-3/cats/derived/DerivedCommutativeMonoid.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedCommutativeMonoid.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form CommutativeMonoid.""")
 type DerivedCommutativeMonoid[A] = Derived[CommutativeMonoid[A]]
 object DerivedCommutativeMonoid:
-  type Or[A] = Derived.Or[CommutativeMonoid[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: CommutativeMonoid[A] =
     import DerivedCommutativeMonoid.given
@@ -22,8 +20,8 @@ object DerivedCommutativeMonoid:
     import Strict.given
     summonInline[DerivedCommutativeMonoid[A]].instance
 
-  given [A](using inst: => ProductInstances[Or, A]): DerivedCommutativeMonoid[A] =
-    Strict.product(using inst.unify)
+  given [A](using inst: => ProductInstances[Derived.Or0[CommutativeMonoid], A]): DerivedCommutativeMonoid[A] =
+    Strict.product
 
   trait Product[F[x] <: CommutativeMonoid[x], A](using @unused inst: ProductInstances[F, A])
       extends DerivedMonoid.Product[F, A],

--- a/core/src/main/scala-3/cats/derived/DerivedCommutativeSemigroup.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedCommutativeSemigroup.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form CommutativeSemigroup.""")
 type DerivedCommutativeSemigroup[A] = Derived[CommutativeSemigroup[A]]
 object DerivedCommutativeSemigroup:
-  type Or[A] = Derived.Or[CommutativeSemigroup[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: CommutativeSemigroup[A] =
     import DerivedCommutativeSemigroup.given
@@ -22,8 +20,8 @@ object DerivedCommutativeSemigroup:
     import Strict.given
     summonInline[DerivedCommutativeSemigroup[A]].instance
 
-  given [A](using inst: => ProductInstances[Or, A]): DerivedCommutativeSemigroup[A] =
-    Strict.product(using inst.unify)
+  given [A](using inst: => ProductInstances[Derived.Or0[CommutativeSemigroup], A]): DerivedCommutativeSemigroup[A] =
+    Strict.product
 
   trait Product[F[x] <: CommutativeSemigroup[x], A](using @unused inst: ProductInstances[F, A])
       extends DerivedSemigroup.Product[F, A],

--- a/core/src/main/scala-3/cats/derived/DerivedEmpty.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedEmpty.scala
@@ -13,8 +13,6 @@ Make sure it satisfies one of the following conditions:
   * enum where exactly one variant forms Empty""")
 type DerivedEmpty[A] = Derived[Empty[A]]
 object DerivedEmpty:
-  type Or[A] = Derived.Or[Empty[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Empty[A] =
     import DerivedEmpty.given
@@ -25,8 +23,8 @@ object DerivedEmpty:
     import Strict.given
     summonInline[DerivedEmpty[A]].instance
 
-  given product[A: ProductInstancesOf[DerivedEmpty.Or]]: DerivedEmpty[A] =
-    Strict.product(using ProductInstances.unify)
+  given product[A: ProductInstancesOf[Derived.Or0[Empty]]]: DerivedEmpty[A] =
+    Strict.product
 
   inline given coproduct[A: CoproductGeneric]: DerivedEmpty[A] =
     Strict.coproduct
@@ -37,4 +35,4 @@ object DerivedEmpty:
 
     @nowarn("id=E197")
     inline given coproduct[A: CoproductGeneric]: DerivedEmpty[A] =
-      Empty(CoproductGeneric.withOnly[DerivedEmpty.Or, A]([a <: A] => (A: DerivedEmpty.Or[a]) => A.unify.empty))
+      Empty(CoproductGeneric.withOnly[Derived.Or0[Empty], A]([a <: A] => (A: Derived.Or[Empty[a]]) => A.empty))

--- a/core/src/main/scala-3/cats/derived/DerivedEq.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedEq.scala
@@ -14,8 +14,6 @@ Make sure that A satisfies one of the following conditions:
   * enum where all variants form Eq""")
 type DerivedEq[A] = Derived[Eq[A]]
 object DerivedEq:
-  type Or[A] = Derived.Or[Eq[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Eq[A] =
     import DerivedEq.given
@@ -29,11 +27,10 @@ object DerivedEq:
   given singleton[A <: Singleton: ValueOf]: DerivedEq[A] =
     Eq.allEqual
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedEq[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[Eq], A]): DerivedEq[A] =
+    Strict.product
 
-  given coproduct[A](using inst: => CoproductInstances[Or, A]): DerivedEq[A] =
-    given CoproductInstances[Eq, A] = inst.unify
+  given coproduct[A](using inst: => CoproductInstances[Derived.Or0[Eq], A]): DerivedEq[A] =
     new Coproduct[Eq, A] {}
 
   trait Product[F[x] <: Eq[x], A](using inst: ProductInstances[F, A]) extends Eq[A]:

--- a/core/src/main/scala-3/cats/derived/DerivedGroup.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedGroup.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form Group.""")
 type DerivedGroup[A] = Derived[Group[A]]
 object DerivedGroup:
-  type Or[A] = Derived.Or[Group[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Group[A] =
     import DerivedGroup.given
@@ -22,8 +20,8 @@ object DerivedGroup:
     import Strict.given
     summonInline[DerivedGroup[A]].instance
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedGroup[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[Group], A]): DerivedGroup[A] =
+    Strict.product
 
   trait Product[F[x] <: Group[x], A: ProductInstancesOf[F]] extends DerivedMonoid.Product[F, A], Group[A]:
     final override def inverse(a: A): A = ProductInstances.map(a)([a] => (F: F[a], x: a) => F.inverse(x))

--- a/core/src/main/scala-3/cats/derived/DerivedHash.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedHash.scala
@@ -15,8 +15,6 @@ Make sure it satisfies one of the following conditions:
   * enum where all variants form Hash""")
 type DerivedHash[A] = Derived[Hash[A]]
 object DerivedHash:
-  type Or[A] = Derived.Or[Hash[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Hash[A] =
     import DerivedHash.given
@@ -39,11 +37,10 @@ object DerivedHash:
   given string[A <: String]: DerivedHash[A] = Hash.fromUniversalHashCode
   given symbol[A <: Symbol]: DerivedHash[A] = Hash.fromUniversalHashCode
 
-  given product[A <: scala.Product](using inst: => ProductInstances[Or, A]): DerivedHash[A] =
-    Strict.product(using inst.unify)
+  given product[A <: scala.Product](using inst: => ProductInstances[Derived.Or0[Hash], A]): DerivedHash[A] =
+    Strict.product
 
-  given coproduct[A](using inst: => CoproductInstances[Or, A]): DerivedHash[A] =
-    given CoproductInstances[Hash, A] = inst.unify
+  given coproduct[A](using inst: => CoproductInstances[Derived.Or0[Hash], A]): DerivedHash[A] =
     new Coproduct[Hash, A] {}
 
   trait Product[F[x] <: Hash[x], A <: scala.Product](using inst: ProductInstances[F, A])

--- a/core/src/main/scala-3/cats/derived/DerivedMonoid.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedMonoid.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form Monoid.""")
 type DerivedMonoid[A] = Derived[Monoid[A]]
 object DerivedMonoid:
-  type Or[A] = Derived.Or[Monoid[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Monoid[A] =
     import DerivedMonoid.given
@@ -22,8 +20,8 @@ object DerivedMonoid:
     import Strict.given
     summonInline[DerivedMonoid[A]].instance
 
-  given [A](using inst: => ProductInstances[Or, A]): DerivedMonoid[A] =
-    Strict.product(using inst.unify)
+  given [A](using inst: => ProductInstances[Derived.Or0[Monoid], A]): DerivedMonoid[A] =
+    Strict.product
 
   trait Product[F[x] <: Monoid[x], A](using inst: ProductInstances[F, A])
       extends DerivedSemigroup.Product[F, A],

--- a/core/src/main/scala-3/cats/derived/DerivedNonEmptyAlternative.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedNonEmptyAlternative.scala
@@ -1,7 +1,6 @@
 package cats.derived
 
-import cats.NonEmptyAlternative
-import cats.derived.Derived.<<<
+import cats.{Applicative, NonEmptyAlternative}
 import shapeless3.deriving.K1.*
 
 import scala.annotation.*
@@ -13,8 +12,6 @@ Make sure it satisfies one of the following conditions:
   * generic case class where all fields form NonEmptyAlternative""")
 type DerivedNonEmptyAlternative[F[_]] = Derived[NonEmptyAlternative[F]]
 object DerivedNonEmptyAlternative:
-  type Or[F[_]] = Derived.Or[NonEmptyAlternative[F]]
-
   @nowarn("msg=unused import")
   inline def apply[F[_]]: NonEmptyAlternative[F] =
     import DerivedNonEmptyAlternative.given
@@ -26,14 +23,16 @@ object DerivedNonEmptyAlternative:
     summonInline[DerivedNonEmptyAlternative[F]].instance
 
   given nested[F[_], G[_]](using
-      F: => DerivedNonEmptyAlternative.Or[F],
-      G: => DerivedApplicative.Or[G]
+      F: => Derived.Or[NonEmptyAlternative[F]],
+      G: => Derived.Or[Applicative[G]]
   ): DerivedNonEmptyAlternative[F <<< G] =
-    new Derived.Lazy(() => F.unify.compose(using G.unify)) with NonEmptyAlternative[F <<< G]:
+    new Derived.Lazy(() => F.compose(using G)) with NonEmptyAlternative[F <<< G]:
       export delegate.*
 
-  given product[F[_]](using inst: => ProductInstances[Or, F]): DerivedNonEmptyAlternative[F] =
-    Strict.product(using inst.unify)
+  given product[F[_]](using
+      inst: => ProductInstances[Derived.Or1[NonEmptyAlternative], F]
+  ): DerivedNonEmptyAlternative[F] =
+    Strict.product
 
   trait Product[T[f[_]] <: NonEmptyAlternative[f], F[_]: ProductInstancesOf[T]]
       extends NonEmptyAlternative[F],

--- a/core/src/main/scala-3/cats/derived/DerivedOrder.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedOrder.scala
@@ -14,8 +14,6 @@ Make sure it satisfies one of the following conditions:
   * enum where all variants form Order""")
 type DerivedOrder[A] = Derived[Order[A]]
 object DerivedOrder:
-  type Or[A] = Derived.Or[Order[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Order[A] =
     import DerivedOrder.given
@@ -29,11 +27,10 @@ object DerivedOrder:
   given singleton[A <: Singleton: ValueOf]: DerivedOrder[A] =
     Order.allEqual
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedOrder[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[Order], A]): DerivedOrder[A] =
+    Strict.product
 
-  given coproduct[A](using inst: => CoproductInstances[Or, A]): DerivedOrder[A] =
-    given CoproductInstances[Order, A] = inst.unify
+  given coproduct[A](using inst: => CoproductInstances[Derived.Or0[Order], A]): DerivedOrder[A] =
     new Coproduct[Order, A] {}
 
   trait Product[T[x] <: Order[x], A](using inst: ProductInstances[T, A]) extends Order[A]:

--- a/core/src/main/scala-3/cats/derived/DerivedPartialOrder.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedPartialOrder.scala
@@ -14,8 +14,6 @@ Make sure it satisfies one of the following conditions:
   * enum where all variants form PartialOrder""")
 type DerivedPartialOrder[A] = Derived[PartialOrder[A]]
 object DerivedPartialOrder:
-  type Or[A] = Derived.Or[PartialOrder[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: PartialOrder[A] =
     import DerivedPartialOrder.given
@@ -29,11 +27,10 @@ object DerivedPartialOrder:
   given singleton[A <: Singleton: ValueOf]: DerivedPartialOrder[A] =
     Order.allEqual
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedPartialOrder[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[PartialOrder], A]): DerivedPartialOrder[A] =
+    Strict.product
 
-  given coproduct[A](using inst: => CoproductInstances[Or, A]): DerivedPartialOrder[A] =
-    given CoproductInstances[PartialOrder, A] = inst.unify
+  given coproduct[A](using inst: => CoproductInstances[Derived.Or0[PartialOrder], A]): DerivedPartialOrder[A] =
     new Coproduct[PartialOrder, A] {}
 
   trait Product[T[x] <: PartialOrder[x], A](using inst: ProductInstances[T, A]) extends PartialOrder[A]:

--- a/core/src/main/scala-3/cats/derived/DerivedSemigroup.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedSemigroup.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form Semigroup.""")
 type DerivedSemigroup[A] = Derived[Semigroup[A]]
 object DerivedSemigroup:
-  type Or[A] = Derived.Or[Semigroup[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Semigroup[A] =
     import DerivedSemigroup.given
@@ -22,8 +20,8 @@ object DerivedSemigroup:
     import Strict.given
     summonInline[DerivedSemigroup[A]].instance
 
-  given [A](using inst: => ProductInstances[Or, A]): DerivedSemigroup[A] =
-    Strict.product(using inst.unify)
+  given [A](using inst: => ProductInstances[Derived.Or0[Semigroup], A]): DerivedSemigroup[A] =
+    Strict.product
 
   trait Product[F[x] <: Semigroup[x], A](using inst: ProductInstances[F, A]) extends Semigroup[A]:
     final override def combine(x: A, y: A): A =

--- a/core/src/main/scala-3/cats/derived/DerivedSemilattice.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedSemilattice.scala
@@ -10,8 +10,6 @@ import scala.compiletime.*
 Make sure it is a case class where all fields form Semilattice.""")
 type DerivedSemilattice[A] = Derived[Semilattice[A]]
 object DerivedSemilattice:
-  type Or[A] = Derived.Or[Semilattice[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Semilattice[A] =
     import DerivedSemilattice.given
@@ -22,8 +20,8 @@ object DerivedSemilattice:
     import Strict.given
     summonInline[DerivedSemilattice[A]].instance
 
-  given product[A](using inst: => ProductInstances[Or, A]): DerivedSemilattice[A] =
-    Strict.product(using inst.unify)
+  given product[A](using inst: => ProductInstances[Derived.Or0[Semilattice], A]): DerivedSemilattice[A] =
+    Strict.product
 
   trait Product[F[x] <: Semilattice[x], A: ProductInstancesOf[F]]
       extends DerivedCommutativeSemigroup.Product[F, A],

--- a/core/src/main/scala-3/cats/derived/DerivedShow.scala
+++ b/core/src/main/scala-3/cats/derived/DerivedShow.scala
@@ -14,8 +14,6 @@ Make sure it satisfies one of the following conditions:
   * enum where all variants form Show""")
 type DerivedShow[A] = Derived[Show[A]]
 object DerivedShow:
-  type Or[A] = Derived.Or[Show[A]]
-
   @nowarn("msg=unused import")
   inline def apply[A]: Show[A] =
     import DerivedShow.given
@@ -38,10 +36,10 @@ object DerivedShow:
   given string[A <: String]: DerivedShow[A] = Show.fromToString
   given symbol[A <: Symbol]: DerivedShow[A] = Show.fromToString
 
-  given [A: ProductInstancesOf[DerivedShow.Or]](using labelling: Labelling[A]): DerivedShow[A] =
-    Strict.product(using labelling, ProductInstances.unify)
+  given [A: ProductInstancesOf[Derived.Or0[Show]]: Labelling]: DerivedShow[A] =
+    Strict.product
 
-  given [A](using => CoproductInstances[Or, A]): DerivedShow[A] =
+  given [A](using => CoproductInstances[Derived.Or0[Show], A]): DerivedShow[A] =
     Strict.coproduct
 
   trait Product[F[x] <: Show[x], A](using inst: ProductInstances[F, A], labelling: Labelling[A]) extends Show[A]:
@@ -73,6 +71,5 @@ object DerivedShow:
     given product[A: Labelling](using => ProductInstances[Show, A]): DerivedShow[A] =
       new Product[Show, A] {}
 
-    given coproduct[A](using inst: => CoproductInstances[Or, A]): DerivedShow[A] =
-      given CoproductInstances[Show, A] = inst.unify
+    given coproduct[A](using inst: => CoproductInstances[Derived.Or0[Show], A]): DerivedShow[A] =
       new Coproduct[Show, A] {}

--- a/core/src/test/scala-3/cats/derived/AlternativeSuite.scala
+++ b/core/src/test/scala-3/cats/derived/AlternativeSuite.scala
@@ -16,7 +16,6 @@
 
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import cats.{Alternative, Applicative}
 import org.scalacheck.Arbitrary

--- a/core/src/test/scala-3/cats/derived/ApplicativeSuite.scala
+++ b/core/src/test/scala-3/cats/derived/ApplicativeSuite.scala
@@ -16,7 +16,6 @@
 
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import cats.{Applicative, Monoid}
 import org.scalacheck.Arbitrary

--- a/core/src/test/scala-3/cats/derived/ApplySuite.scala
+++ b/core/src/test/scala-3/cats/derived/ApplySuite.scala
@@ -16,7 +16,6 @@
 
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import cats.{Apply, Semigroup}
 import shapeless3.deriving.Const

--- a/core/src/test/scala-3/cats/derived/FoldableSuite.scala
+++ b/core/src/test/scala-3/cats/derived/FoldableSuite.scala
@@ -16,7 +16,6 @@
 
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.{Eval, Foldable}
 import cats.laws.discipline.*
 import cats.syntax.all.given

--- a/core/src/test/scala-3/cats/derived/FunctorSuite.scala
+++ b/core/src/test/scala-3/cats/derived/FunctorSuite.scala
@@ -16,7 +16,6 @@
 
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.{Contravariant, Functor}
 import cats.laws.discipline.*
 import cats.laws.discipline.eq.*

--- a/core/src/test/scala-3/cats/derived/InvariantSuite.scala
+++ b/core/src/test/scala-3/cats/derived/InvariantSuite.scala
@@ -17,7 +17,6 @@
 package cats.derived
 
 import cats.Invariant
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import cats.laws.discipline.arbitrary.*
 import cats.laws.discipline.eq.*

--- a/core/src/test/scala-3/cats/derived/MonoidKSuite.scala
+++ b/core/src/test/scala-3/cats/derived/MonoidKSuite.scala
@@ -1,6 +1,5 @@
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.{Applicative, Eval, Monoid, MonoidK}
 import cats.laws.discipline.{MonoidKTests, SerializableTests}
 import shapeless3.deriving.Const

--- a/core/src/test/scala-3/cats/derived/NonEmptyAlternativeSuite.scala
+++ b/core/src/test/scala-3/cats/derived/NonEmptyAlternativeSuite.scala
@@ -16,7 +16,6 @@
 
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import cats.{Applicative, NonEmptyAlternative}
 import org.scalacheck.Arbitrary

--- a/core/src/test/scala-3/cats/derived/NonEmptyTraverseSuite.scala
+++ b/core/src/test/scala-3/cats/derived/NonEmptyTraverseSuite.scala
@@ -18,7 +18,6 @@ package cats.derived
 
 import cats.{NonEmptyTraverse, Traverse}
 import cats.data.{NonEmptyList, OneAnd}
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import shapeless3.deriving.Const
 

--- a/core/src/test/scala-3/cats/derived/ReducibleSuite.scala
+++ b/core/src/test/scala-3/cats/derived/ReducibleSuite.scala
@@ -18,7 +18,6 @@ package cats.derived
 
 import cats.{Eval, Foldable, Reducible}
 import cats.data.{NonEmptyList, OneAnd}
-import cats.derived.Derived.<<<
 import cats.laws.discipline.*
 import cats.syntax.all.given
 import shapeless3.deriving.Const

--- a/core/src/test/scala-3/cats/derived/SemigroupKSuite.scala
+++ b/core/src/test/scala-3/cats/derived/SemigroupKSuite.scala
@@ -1,6 +1,5 @@
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.{Apply, Eval, Semigroup, SemigroupK}
 import cats.laws.discipline.{SemigroupKTests, SerializableTests}
 import shapeless3.deriving.Const

--- a/core/src/test/scala-3/cats/derived/TraverseSuite.scala
+++ b/core/src/test/scala-3/cats/derived/TraverseSuite.scala
@@ -1,6 +1,5 @@
 package cats.derived
 
-import cats.derived.Derived.<<<
 import cats.Traverse
 import cats.laws.discipline.*
 import shapeless3.deriving.Const


### PR DESCRIPTION
Add implicit conversions instead of having to call `unify` explicitly